### PR TITLE
fix volume permissions

### DIFF
--- a/1/Dockerfile
+++ b/1/Dockerfile
@@ -46,7 +46,7 @@ ENV ALLOW_PLAINTEXT_LISTENER="no" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/kafka/bin:$PATH"
 
 EXPOSE 9092
-
+RUN chown 1001:1001 /bitnami/kafka
 USER 1001
 ENTRYPOINT ["/app-entrypoint.sh"]
 CMD ["/run.sh"]

--- a/1/debian-9/Dockerfile
+++ b/1/debian-9/Dockerfile
@@ -47,7 +47,7 @@ ENV ALLOW_PLAINTEXT_LISTENER="no" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/kafka/bin:$PATH"
 
 EXPOSE 9092
-
+RUN chown 1001:1001 /bitnami/kafka
 USER 1001
 ENTRYPOINT [ "/app-entrypoint.sh" ]
 CMD [ "/run.sh" ]

--- a/2/debian-9/Dockerfile
+++ b/2/debian-9/Dockerfile
@@ -47,7 +47,7 @@ ENV ALLOW_PLAINTEXT_LISTENER="no" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/kafka/bin:$PATH"
 
 EXPOSE 9092
-
+RUN chown 1001:1001 /bitnami/kafka
 USER 1001
 ENTRYPOINT [ "/app-entrypoint.sh" ]
 CMD [ "/run.sh" ]

--- a/2/debian-9/Dockerfile
+++ b/2/debian-9/Dockerfile
@@ -47,7 +47,11 @@ ENV ALLOW_PLAINTEXT_LISTENER="no" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/kafka/bin:$PATH"
 
 EXPOSE 9092
-RUN chown 1001:1001 /bitnami/kafka
+
+RUN mkdir -p /bitnami/kafka
+RUN chown -R 1001:1001 /bitnami/kafka
+RUN chown -R 1001:1001 /opt/bitnami/kafka/
+
 USER 1001
 ENTRYPOINT [ "/app-entrypoint.sh" ]
 CMD [ "/run.sh" ]


### PR DESCRIPTION
I need your help in here. With `chmod -R 1001:1001` it did worked, although I'm not sure which part of it. Always been checking only kafka 2x Dockerfile. I believe you need to do testing yourself. Now this works for me when using rexray volume driver, before it didn't worked. As we are in production now I can't really test it anymore, but you really need permission for the `/bitnami/kafka` as it's uuid is 0:0, instead of 1001:1001 :) 