### PR TITLE
Fix for https://github.com/bitnami/bitnami-docker-kafka/issues/53

### DIFF
--- a/1/debian-9/rootfs/libkafka.sh
+++ b/1/debian-9/rootfs/libkafka.sh
@@ -174,7 +174,7 @@ kafka_validate() {
     if is_boolean_yes "$ALLOW_PLAINTEXT_LISTENER"; then
         warn "You set the environment variable ALLOW_PLAINTEXT_LISTENER=$ALLOW_PLAINTEXT_LISTENER. For safety reasons, do not use this flag in a production environment."
     fi
-    if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]]; then
+    if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]] || [[ "$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP" =~ SASL_SSL ]]; then
         if [[ ! -f "$KAFKA_CONFDIR"/certs/kafka.keystore.jks ]] || [[ ! -f "$KAFKA_CONFDIR"/certs/kafka.truststore.jks ]]; then
             error "In order to configure the SASL_SSL listener for Kafka you must mount your kafka.keystore.jks and kafka.trustore.jks certificates to the $KAFKA_CONFDIR/certs directory."
             exit 1
@@ -324,10 +324,15 @@ kafka_initialize() {
         cp -r "$KAFKA_BASEDIR"/configtmp/. "$KAFKA_CONFDIR"
         kafka_server_conf_set log.dirs "$KAFKA_DATADIR"
         kafka_configure_from_environment_variables
-        if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]]; then
+        if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]] || [[ "$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP" =~ SASL_SSL ]]; then
             kafka_configure_sasl_ssl_listener
-        elif [[ "$KAFKA_CFG_LISTENERS" =~ SASL_PLAINTEXT ]]; then
+        elif [[ "$KAFKA_CFG_LISTENERS" =~ SASL_PLAINTEXT ]] || [[ "$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP" =~ SASL_PLAINTEXT ]]; then
             kafka_configure_sasl_plaintext_listener
+        fi
+
+        # Remove security.inter.broker.protocol if KAFKA_CFG_INTER_BROKER_LISTENER_NAME is configured
+        if [[ ! -z "$KAFKA_CFG_INTER_BROKER_LISTENER_NAME" ]]; then
+            sed -i '/security.inter.broker.protocol/d' "$KAFKA_CONF_FILE"
         fi
     fi
     rm -rf "$KAFKA_BASEDIR"/configtmp

--- a/1/debian-9/rootfs/run.sh
+++ b/1/debian-9/rootfs/run.sh
@@ -13,7 +13,7 @@ set -o pipefail
 # Load Kafka environment variables
 eval "$(kafka_env)"
 
-if [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL ]]; then
+if [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL ]] || [[ "${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-}" =~ SASL ]]; then
     export KAFKA_OPTS="-Djava.security.auth.login.config=$KAFKA_HOME/conf/kafka_jaas.conf"
 fi
 

--- a/1/ol-7/rootfs/libkafka.sh
+++ b/1/ol-7/rootfs/libkafka.sh
@@ -174,7 +174,7 @@ kafka_validate() {
     if is_boolean_yes "$ALLOW_PLAINTEXT_LISTENER"; then
         warn "You set the environment variable ALLOW_PLAINTEXT_LISTENER=$ALLOW_PLAINTEXT_LISTENER. For safety reasons, do not use this flag in a production environment."
     fi
-    if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]]; then
+    if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]] || [[ "$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP" =~ SASL_SSL ]]; then
         if [[ ! -f "$KAFKA_CONFDIR"/certs/kafka.keystore.jks ]] || [[ ! -f "$KAFKA_CONFDIR"/certs/kafka.truststore.jks ]]; then
             error "In order to configure the SASL_SSL listener for Kafka you must mount your kafka.keystore.jks and kafka.trustore.jks certificates to the $KAFKA_CONFDIR/certs directory."
             exit 1
@@ -324,10 +324,15 @@ kafka_initialize() {
         cp -r "$KAFKA_BASEDIR"/configtmp/. "$KAFKA_CONFDIR"
         kafka_server_conf_set log.dirs "$KAFKA_DATADIR"
         kafka_configure_from_environment_variables
-        if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]]; then
+        if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]] || [[ "$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP" =~ SASL_SSL ]]; then
             kafka_configure_sasl_ssl_listener
-        elif [[ "$KAFKA_CFG_LISTENERS" =~ SASL_PLAINTEXT ]]; then
+        elif [[ "$KAFKA_CFG_LISTENERS" =~ SASL_PLAINTEXT ]] || [[ "$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP" =~ SASL_PLAINTEXT ]]; then
             kafka_configure_sasl_plaintext_listener
+        fi
+
+        # Remove security.inter.broker.protocol if KAFKA_CFG_INTER_BROKER_LISTENER_NAME is configured
+        if [[ ! -z "$KAFKA_CFG_INTER_BROKER_LISTENER_NAME" ]]; then
+            sed -i '/security.inter.broker.protocol/d' "$KAFKA_CONF_FILE"
         fi
     fi
     rm -rf "$KAFKA_BASEDIR"/configtmp

--- a/1/ol-7/rootfs/run.sh
+++ b/1/ol-7/rootfs/run.sh
@@ -13,7 +13,7 @@ set -o pipefail
 # Load Kafka environment variables
 eval "$(kafka_env)"
 
-if [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL ]]; then
+if [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL ]] || [[ "${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-}" =~ SASL ]]; then
     export KAFKA_OPTS="-Djava.security.auth.login.config=$KAFKA_HOME/conf/kafka_jaas.conf"
 fi
 

--- a/2/debian-9/rootfs/libkafka.sh
+++ b/2/debian-9/rootfs/libkafka.sh
@@ -174,7 +174,7 @@ kafka_validate() {
     if is_boolean_yes "$ALLOW_PLAINTEXT_LISTENER"; then
         warn "You set the environment variable ALLOW_PLAINTEXT_LISTENER=$ALLOW_PLAINTEXT_LISTENER. For safety reasons, do not use this flag in a production environment."
     fi
-    if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]]; then
+    if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]] || [[ "$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP" =~ SASL_SSL ]]; then
         if [[ ! -f "$KAFKA_CONFDIR"/certs/kafka.keystore.jks ]] || [[ ! -f "$KAFKA_CONFDIR"/certs/kafka.truststore.jks ]]; then
             error "In order to configure the SASL_SSL listener for Kafka you must mount your kafka.keystore.jks and kafka.trustore.jks certificates to the $KAFKA_CONFDIR/certs directory."
             exit 1
@@ -308,12 +308,6 @@ kafka_configure_from_environment_variables() {
 #   None
 #########################
 kafka_initialize() {
-    # Since we remove this directory afterwards, it allows us to check if Kafka had already been initialized
-    if [[ ! -d "$KAFKA_BASEDIR"/configtmp ]]; then
-        info "Kafka has already been initialized"
-        return
-    fi
-
     info "Initializing Kafka..."
 
     # Check for mounted configuration files
@@ -324,10 +318,15 @@ kafka_initialize() {
         cp -r "$KAFKA_BASEDIR"/configtmp/. "$KAFKA_CONFDIR"
         kafka_server_conf_set log.dirs "$KAFKA_DATADIR"
         kafka_configure_from_environment_variables
-        if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]]; then
+        if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]] || [[ "$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP" =~ SASL_SSL ]]; then
             kafka_configure_sasl_ssl_listener
-        elif [[ "$KAFKA_CFG_LISTENERS" =~ SASL_PLAINTEXT ]]; then
+        elif [[ "$KAFKA_CFG_LISTENERS" =~ SASL_PLAINTEXT ]] || [[ "$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP" =~ SASL_PLAINTEXT ]]; then
             kafka_configure_sasl_plaintext_listener
+        fi
+
+        # Remove security.inter.broker.protocol if KAFKA_CFG_INTER_BROKER_LISTENER_NAME is configured
+        if [[ ! -z "$KAFKA_CFG_INTER_BROKER_LISTENER_NAME" ]]; then
+            sed -i '/security.inter.broker.protocol/d' "$KAFKA_CONF_FILE"
         fi
     fi
     rm -rf "$KAFKA_BASEDIR"/configtmp

--- a/2/debian-9/rootfs/run.sh
+++ b/2/debian-9/rootfs/run.sh
@@ -13,7 +13,7 @@ set -o pipefail
 # Load Kafka environment variables
 eval "$(kafka_env)"
 
-if [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL ]]; then
+if [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL ]] || [[ "${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-}" =~ SASL ]]; then
     export KAFKA_OPTS="-Djava.security.auth.login.config=$KAFKA_HOME/conf/kafka_jaas.conf"
 fi
 

--- a/2/ol-7/rootfs/libkafka.sh
+++ b/2/ol-7/rootfs/libkafka.sh
@@ -174,7 +174,7 @@ kafka_validate() {
     if is_boolean_yes "$ALLOW_PLAINTEXT_LISTENER"; then
         warn "You set the environment variable ALLOW_PLAINTEXT_LISTENER=$ALLOW_PLAINTEXT_LISTENER. For safety reasons, do not use this flag in a production environment."
     fi
-    if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]]; then
+    if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]] || [[ "$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP" =~ SASL_SSL ]]; then
         if [[ ! -f "$KAFKA_CONFDIR"/certs/kafka.keystore.jks ]] || [[ ! -f "$KAFKA_CONFDIR"/certs/kafka.truststore.jks ]]; then
             error "In order to configure the SASL_SSL listener for Kafka you must mount your kafka.keystore.jks and kafka.trustore.jks certificates to the $KAFKA_CONFDIR/certs directory."
             exit 1
@@ -324,10 +324,15 @@ kafka_initialize() {
         cp -r "$KAFKA_BASEDIR"/configtmp/. "$KAFKA_CONFDIR"
         kafka_server_conf_set log.dirs "$KAFKA_DATADIR"
         kafka_configure_from_environment_variables
-        if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]]; then
+        if [[ "$KAFKA_CFG_LISTENERS" =~ SASL_SSL ]] || [[ "$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP" =~ SASL_SSL ]]; then
             kafka_configure_sasl_ssl_listener
-        elif [[ "$KAFKA_CFG_LISTENERS" =~ SASL_PLAINTEXT ]]; then
+        elif [[ "$KAFKA_CFG_LISTENERS" =~ SASL_PLAINTEXT ]] || [[ "$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP" =~ SASL_PLAINTEXT ]]; then
             kafka_configure_sasl_plaintext_listener
+        fi
+
+        # Remove security.inter.broker.protocol if KAFKA_CFG_INTER_BROKER_LISTENER_NAME is configured
+        if [[ ! -z "$KAFKA_CFG_INTER_BROKER_LISTENER_NAME" ]]; then
+            sed -i '/security.inter.broker.protocol/d' "$KAFKA_CONF_FILE"
         fi
     fi
     rm -rf "$KAFKA_BASEDIR"/configtmp

--- a/2/ol-7/rootfs/run.sh
+++ b/2/ol-7/rootfs/run.sh
@@ -13,7 +13,7 @@ set -o pipefail
 # Load Kafka environment variables
 eval "$(kafka_env)"
 
-if [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL ]]; then
+if [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL ]] || [[ "${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-}" =~ SASL ]]; then
     export KAFKA_OPTS="-Djava.security.auth.login.config=$KAFKA_HOME/conf/kafka_jaas.conf"
 fi
 


### PR DESCRIPTION
**Description of the change**

Fix for the issue mentioned in https://github.com/bitnami/bitnami-docker-kafka/issues/53
Basically, added support to detect if SASL_SSL is configured when using multiple listeners with LISTENER_SECURITY_PROTOCOL_MAP

**Benefits**

Allows us to use SASL_SSL with multiple listeners.

**Possible drawbacks**

None that I can think of.

**Applicable issues**

53

**Additional information**


