### PR TITLE
Added support for scram authentication mechanism

### DIFF
--- a/2/debian-9/rootfs/libkafka.sh
+++ b/2/debian-9/rootfs/libkafka.sh
@@ -246,6 +246,8 @@ KafkaServer {
    password="{{KAFKA_INTER_BROKER_PASSWORD}}"
    user_{{KAFKA_INTER_BROKER_USER}}="{{KAFKA_INTER_BROKER_PASSWORD}}"
    user_{{KAFKA_BROKER_USER}}="{{KAFKA_BROKER_PASSWORD}}";
+
+   org.apache.kafka.common.security.scram.ScramLoginModule required;
 };
 EOF
     if [[ -n "$KAFKA_ZOOKEEPER_USER" ]] && [[ -n "$KAFKA_ZOOKEEPER_PASSWORD" ]]; then
@@ -282,7 +284,7 @@ kafka_configure_sasl_ssl_listener() {
     kafka_server_conf_set ssl.truststore.location "$KAFKA_CONFDIR"/certs/kafka.truststore.jks
     kafka_server_conf_set ssl.truststore.password "$KAFKA_CERTIFICATE_PASSWORD"
     kafka_server_conf_set sasl.mechanism.inter.broker.protocol PLAIN
-    kafka_server_conf_set sasl.enabled.mechanisms PLAIN
+    kafka_server_conf_set sasl.enabled.mechanisms PLAIN,SCRAM-SHA-256,SCRAM-SHA-512
     kafka_server_conf_set security.inter.broker.protocol SASL_SSL
     kafka_server_conf_set ssl.client.auth required
     # Set producer/consumer configuration
@@ -309,7 +311,7 @@ kafka_configure_sasl_plaintext_listener() {
     kafka_generate_jaas_authentication_file
     # Set Kafka configuration
     kafka_server_conf_set sasl.mechanism.inter.broker.protocol PLAIN
-    kafka_server_conf_set sasl.enabled.mechanisms PLAIN
+    kafka_server_conf_set sasl.enabled.mechanisms PLAIN,SCRAM-SHA-256,SCRAM-SHA-512
     kafka_server_conf_set security.inter.broker.protocol SASL_PLAINTEXT
     # Set producer/consumer configuration
     kafka_producer_consumer_conf_set security.protocol SASL_SSL

--- a/2/ol-7/rootfs/libkafka.sh
+++ b/2/ol-7/rootfs/libkafka.sh
@@ -246,6 +246,8 @@ KafkaServer {
    password="{{KAFKA_INTER_BROKER_PASSWORD}}"
    user_{{KAFKA_INTER_BROKER_USER}}="{{KAFKA_INTER_BROKER_PASSWORD}}"
    user_{{KAFKA_BROKER_USER}}="{{KAFKA_BROKER_PASSWORD}}";
+
+   org.apache.kafka.common.security.scram.ScramLoginModule required;
 };
 EOF
     if [[ -n "$KAFKA_ZOOKEEPER_USER" ]] && [[ -n "$KAFKA_ZOOKEEPER_PASSWORD" ]]; then
@@ -282,7 +284,7 @@ kafka_configure_sasl_ssl_listener() {
     kafka_server_conf_set ssl.truststore.location "$KAFKA_CONFDIR"/certs/kafka.truststore.jks
     kafka_server_conf_set ssl.truststore.password "$KAFKA_CERTIFICATE_PASSWORD"
     kafka_server_conf_set sasl.mechanism.inter.broker.protocol PLAIN
-    kafka_server_conf_set sasl.enabled.mechanisms PLAIN
+    kafka_server_conf_set sasl.enabled.mechanisms PLAIN,SCRAM-SHA-256,SCRAM-SHA-512
     kafka_server_conf_set security.inter.broker.protocol SASL_SSL
     kafka_server_conf_set ssl.client.auth required
     # Set producer/consumer configuration
@@ -309,7 +311,7 @@ kafka_configure_sasl_plaintext_listener() {
     kafka_generate_jaas_authentication_file
     # Set Kafka configuration
     kafka_server_conf_set sasl.mechanism.inter.broker.protocol PLAIN
-    kafka_server_conf_set sasl.enabled.mechanisms PLAIN
+    kafka_server_conf_set sasl.enabled.mechanisms PLAIN,SCRAM-SHA-256,SCRAM-SHA-512
     kafka_server_conf_set security.inter.broker.protocol SASL_PLAINTEXT
     # Set producer/consumer configuration
     kafka_producer_consumer_conf_set security.protocol SASL_SSL


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add SCRAM-SHA-256 and SCRAM-SHA-512 to SASL mechanisms.

**Benefits**

Enable the use of SASL/SCRAM with all its benefits, for example, username and password hashes are stored in Zookeeper, which allows you to scale security without rebooting brokers.

**Use of SASL/SCRAM**
More information on the use of SASL/SCRAM can be found at [https://docs.confluent.io/current/kafka/authentication_sasl/authentication_sasl_scram.html](https://docs.confluent.io/current/kafka/authentication_sasl/authentication_sasl_scram.html)
