### PR TITLE
Fix SASL_PLAINTEXT producer/consumer.properties incorrectly using SASL_SSL security.protocol

### DIFF
--- a/2/debian-10/rootfs/libkafka.sh
+++ b/2/debian-10/rootfs/libkafka.sh
@@ -318,7 +318,7 @@ kafka_configure_sasl_plaintext_listener() {
     kafka_server_conf_set sasl.enabled.mechanisms PLAIN,SCRAM-SHA-256,SCRAM-SHA-512
     kafka_server_conf_set security.inter.broker.protocol SASL_PLAINTEXT
     # Set producer/consumer configuration
-    kafka_producer_consumer_conf_set security.protocol SASL_SSL
+    kafka_producer_consumer_conf_set security.protocol SASL_PLAINTEXT
     kafka_producer_consumer_conf_set sasl.mechanism PLAIN
 }
 

--- a/2/ol-7/rootfs/libkafka.sh
+++ b/2/ol-7/rootfs/libkafka.sh
@@ -318,7 +318,7 @@ kafka_configure_sasl_plaintext_listener() {
     kafka_server_conf_set sasl.enabled.mechanisms PLAIN,SCRAM-SHA-256,SCRAM-SHA-512
     kafka_server_conf_set security.inter.broker.protocol SASL_PLAINTEXT
     # Set producer/consumer configuration
-    kafka_producer_consumer_conf_set security.protocol SASL_SSL
+    kafka_producer_consumer_conf_set security.protocol SASL_PLAINTEXT
     kafka_producer_consumer_conf_set sasl.mechanism PLAIN
 }
 


### PR DESCRIPTION
**Description of the change**

Fix typo in ``kafka_configure_sasl_plaintext_listener()`` from ``security.protocol SASL_SSL`` to ``SASL_PLAINTEXT``

**Benefits**

Using generated properties/consumer.properties in kafka commands inside docker container as in readme instructions now works with SASL_PLAINTEXT listener.

**Applicable issues**
Fixes #84