### PR TITLE
Fix 94

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/kafka/run.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/kafka/run.sh
@@ -15,7 +15,7 @@ set -o pipefail
 eval "$(kafka_env)"
 
 if [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL ]] || [[ "${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-}" =~ SASL ]]; then
-    export KAFKA_OPTS="-Djava.security.auth.login.config=$KAFKA_HOME/conf/kafka_jaas.conf"
+    export KAFKA_OPTS="-Djava.security.auth.login.config=$KAFKA_CONFDIR/kafka_jaas.conf"
 fi
 
 flags=("$KAFKA_CONF_FILE")

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -281,7 +281,6 @@ EOF
 #   None
 #########################
 kafka_configure_ssl_listener() {
-    kafka_generate_jaas_authentication_file
     # Set Kafka configuration
     kafka_server_conf_set ssl.keystore.location "$KAFKA_CONFDIR"/certs/kafka.keystore.jks
     kafka_server_conf_set ssl.keystore.password "$KAFKA_CERTIFICATE_PASSWORD"
@@ -310,6 +309,7 @@ kafka_configure_ssl_listener() {
 kafka_configure_sasl_ssl_listener() {
     info "SASL_SSL listener detected, enabling SASL_SSL settings"
     kafka_configure_ssl_listener
+    kafka_generate_jaas_authentication_file
     # Set Kafka configuration
     kafka_server_conf_set security.inter.broker.protocol SASL_SSL
     kafka_server_conf_set sasl.mechanism.inter.broker.protocol PLAIN


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
First one is in `run.sh` where it is still using `KAFKA_HOME` instead of `KAFKA_CONFIGDIR` when SASL is configured
```
export KAFKA_OPTS="-Djava.security.auth.login.config=$KAFKA_HOME/conf/kafka_jaas.conf"
```

Second, in `libkafka.sh`
* `kafka_configure_ssl_listener` is calling `kafka_generate_jaas_authentication_file` but it should NOT.
* `kafka_configure_sasl_ssl_listener` is NOT calling `kafka_generate_jaas_authentication_file` but it should.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Kafka broker with SSL_SASL will work.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
Not aware of any.

**Applicable issues**

#94 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

Sample `docker-compose.yaml`
```version: '3.5'

services:
  zookeeper:
    image: 'bitnami/zookeeper:latest'
    container_name: zookeeper
    hostname: zookeeper
    ports:
      - 2181:2181
    environment:
      - ALLOW_ANONYMOUS_LOGIN=yes

  kafka:
    image: 'bitnami/kafka:latest'
    container_name: kafka
    hostname: kafka
    depends_on:
      - zookeeper
    ports:
      - '9092:9092'
      - '9093:9093'
    volumes:
      - "tmp-drive:/kafka"
    environment:
      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
      - KAFKA_CFG_LISTENERS=SASL_SSL://:9093, PLAINTEXT://:9092
      - KAFKA_CFG_ADVERTISED_LISTENERS=SASL_SSL://${HOSTNAME}:9093, PLAINTEXT://${HOSTNAME}:9092
      - ALLOW_PLAINTEXT_LISTENER=yes
      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
      - KAFKA_INTER_BROKER_USER=brokeruser
      - KAFKA_INTER_BROKER_PASSWORD=brokerpassword
      - KAFKA_BROKER_USER=kafkauser
      - KAFKA_BROKER_PASSWORD=kafkapassword
      - KAFKA_CERTIFICATE_PASSWORD=password
    volumes:
        - './ssl/kafka.server.keystore.jks:/bitnami/kafka/config/certs/kafka.keystore.jks:ro'
        - './ssl/kafka.server.truststore.jks:/bitnami/kafka/config/certs/kafka.truststore.jks:ro'
```

