### PR TITLE
Refactor listeners and authentication configuration

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -106,10 +106,9 @@ export PATH="${KAFKA_BASE_DIR}/bin:$PATH"
 export ALLOW_PLAINTEXT_LISTENER="${ALLOW_PLAINTEXT_LISTENER:-no}"
 export KAFKA_INTER_BROKER_USER="${KAFKA_INTER_BROKER_USER:-user}"
 export KAFKA_INTER_BROKER_PASSWORD="${KAFKA_INTER_BROKER_PASSWORD:-bitnami}"
-export KAFKA_BROKER_USER="${KAFKA_BROKER_USER:-user}"
-export KAFKA_BROKER_PASSWORD="${KAFKA_BROKER_PASSWORD:-bitnami}"
+export KAFKA_CLIENT_USER="${KAFKA_CLIENT_USER:-user}"
+export KAFKA_CLIENT_PASSWORD="${KAFKA_CLIENT_PASSWORD:-bitnami}"
 export KAFKA_HEAP_OPTS="${KAFKA_HEAP_OPTS:-"-Xmx1024m -Xms1024m"}"
-export KAFKA_PORT_NUMBER="${KAFKA_PORT_NUMBER:-9092}"
 export KAFKA_ZOOKEEPER_PASSWORD="${KAFKA_ZOOKEEPER_PASSWORD:-}"
 export KAFKA_ZOOKEEPER_USER="${KAFKA_ZOOKEEPER_USER:-}"
 export KAFKA_CFG_ADVERTISED_LISTENERS="${KAFKA_CFG_ADVERTISED_LISTENERS:-"PLAINTEXT://:9092"}"
@@ -181,7 +180,6 @@ kafka_create_alias_environment_variables() {
     kafka_declare_alias_env "KAFKA_CFG_LOG_DIRS" "KAFKA_LOGS_DIRS"
     kafka_declare_alias_env "KAFKA_CFG_LOG_SEGMENT_BYTES" "KAFKA_SEGMENT_BYTES"
     kafka_declare_alias_env "KAFKA_CFG_MESSAGE_MAX_BYTES" "KAFKA_MAX_MESSAGE_BYTES"
-    kafka_declare_alias_env "KAFKA_CFG_PORT" "KAFKA_PORT_NUMBER"
     kafka_declare_alias_env "KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS" "KAFKA_ZOOKEEPER_CONNECT_TIMEOUT_MS"
     kafka_declare_alias_env "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE" "KAFKA_AUTO_CREATE_TOPICS_ENABLE"
     for s in "${suffixes[@]}"; do
@@ -201,20 +199,44 @@ kafka_create_alias_environment_variables() {
 kafka_validate() {
     debug "Validating settings in KAFKA_* env vars..."
     local error_code=0
+    local internal_port
+    local client_port
 
     # Auxiliary functions
     print_validation_error() {
         error "$1"
         error_code=1
     }
-
-    local validate_port_args=()
-    ! am_i_root && validate_port_args+=("-unprivileged")
-    for var in "KAFKA_PORT_NUMBER"; do
-        if ! err=$(validate_port "${validate_port_args[@]}" "${!var}"); then
-            print_validation_error "An invalid port was specified in the environment variable $var: $err"
+    check_conflicting_ports() {
+        local -r total="$#"
+        for i in $(seq 1 "$((total - 1))"); do
+            for j in $(seq "$((i + 1))" "$total"); do
+                if (( "$i" == "$j" )); then
+                    print_validation_error "There are listeners bound to the same port"
+                fi
+            done
+        done
+    }
+    check_allowed_port() {
+        local validate_port_args=()
+        ! am_i_root && validate_port_args+=("-unprivileged")
+        if ! err=$(validate_port "${validate_port_args[@]}" "$1"); then
+            print_validation_error "An invalid port was specified in the environment variable KAFKA_CFG_LISTENERS: $err"
         fi
-    done
+    }
+
+    if [[ ${KAFKA_CFG_LISTENERS:-} = *"INTERNAL"* ]] || [[ ${KAFKA_CFG_LISTENERS:-} = *"CLIENT"* ]]; then
+        if [[ ${KAFKA_CFG_LISTENERS:-} =~ INTERNAL:\/\/:([0-9]*) ]]; then
+            internal_port="${BASH_REMATCH[1]}"
+            check_allowed_port "$internal_port"
+        fi
+        if [[ ${KAFKA_CFG_LISTENERS:-} =~ CLIENT:\/\/:([0-9]*) ]]; then
+            client_port="${BASH_REMATCH[1]}"
+            check_allowed_port "$client_port"
+        fi
+    fi
+    [[ -n ${internal_port:-} && -n ${client_port:-} ]] && check_conflicting_ports "$internal_port" "$client_port"
+
     if is_boolean_yes "$ALLOW_PLAINTEXT_LISTENER"; then
         warn "You set the environment variable ALLOW_PLAINTEXT_LISTENER=$ALLOW_PLAINTEXT_LISTENER. For safety reasons, do not use this flag in a production environment."
     fi
@@ -222,13 +244,17 @@ kafka_validate() {
         # DEPRECATED. Check for jks files in old conf directory to maintain compatibility with Helm chart.
         if ([[ ! -f "$KAFKA_BASE_DIR"/conf/certs/kafka.keystore.jks ]] || [[ ! -f "$KAFKA_BASE_DIR"/conf/certs/kafka.truststore.jks ]]) \
             && ([[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/kafka.keystore.jks ]] || [[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/kafka.truststore.jks ]]); then
-            print_validation_error "In order to configure the SASL_SSL listener for Kafka you must mount your kafka.keystore.jks and kafka.truststore.jks certificates to the $KAFKA_MOUNTED_CONF_DIR/certs directory."
+            print_validation_error "In order to configure the TLS encryption for Kafka you must mount your kafka.keystore.jks and kafka.truststore.jks certificates to the $KAFKA_MOUNTED_CONF_DIR/certs directory."
+        fi
+    elif [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL ]] || [[ "${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-}" =~ SASL ]]; then
+        if [[ -z "$KAFKA_CLIENT_PASSWORD" ]] && [[ -z "$KAFKA_INTER_BROKER_PASSWORD" ]]; then
+            print_validation_error "In order to configure SASL authentication for Kafka, you must provide the SASL credentials."
         fi
     elif ! is_boolean_yes "$ALLOW_PLAINTEXT_LISTENER"; then
         print_validation_error "The KAFKA_CFG_LISTENERS environment variable does not configure a secure listener. Set the environment variable ALLOW_PLAINTEXT_LISTENER=yes to allow the container to be started with a plaintext listener. This is only recommended for development."
     fi
 
-    [[ "$error_code" -eq 0 ]] || exit "$error_code"
+    [[ "$error_code" -eq 0 ]] || return "$error_code"
 }
 
 ########################
@@ -236,49 +262,76 @@ kafka_validate() {
 # Globals:
 #   KAFKA_*
 # Arguments:
-#   None
+#   $1 - Authentication protocol to use for the internal listener
+#   $1 - Authentication protocol to use for the client listener
 # Returns:
 #   None
 #########################
 kafka_generate_jaas_authentication_file() {
+    local -r internal_protocol="${1:?missing environment variable internal_protocol}"
+    local -r client_protocol="${2:?missing environment variable client_protocol}"
+
     if [[ ! -f "${KAFKA_CONF_DIR}/kafka_jaas.conf" ]]; then
         info "Generating JAAS authentication file"
-        render-template > "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
+        if [[ "$client_protocol" =~ "SASL" ]]; then
+            render-template >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
 KafkaClient {
    org.apache.kafka.common.security.plain.PlainLoginModule required
-   username="{{KAFKA_BROKER_USER}}"
-   password="{{KAFKA_BROKER_PASSWORD}}";
-};
-
+   username="{{KAFKA_CLIENT_USER}}"
+   password="{{KAFKA_CLIENT_PASSWORD}}";
+   };
+EOF
+        fi
+        if [[ "$client_protocol" =~ "SASL" ]] && [[ "$internal_protocol" =~ "SASL" ]]; then
+            render-template >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
 KafkaServer {
    org.apache.kafka.common.security.plain.PlainLoginModule required
    username="{{KAFKA_INTER_BROKER_USER}}"
    password="{{KAFKA_INTER_BROKER_PASSWORD}}"
    user_{{KAFKA_INTER_BROKER_USER}}="{{KAFKA_INTER_BROKER_PASSWORD}}"
-   user_{{KAFKA_BROKER_USER}}="{{KAFKA_BROKER_PASSWORD}}";
+   user_{{KAFKA_CLIENT_USER}}="{{KAFKA_CLIENT_PASSWORD}}";
 
    org.apache.kafka.common.security.scram.ScramLoginModule required;
-};
+   };
 EOF
-        if [[ -n "$KAFKA_ZOOKEEPER_USER" ]] && [[ -n "$KAFKA_ZOOKEEPER_PASSWORD" ]]; then
-            info "Configuring ZooKeeper client credentials"
+        elif [[ "$client_protocol" =~ "SASL" ]]; then
             render-template >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
+KafkaServer {
+   org.apache.kafka.common.security.plain.PlainLoginModule required
+   user_{{KAFKA_CLIENT_USER}}="{{KAFKA_CLIENT_PASSWORD}}";
 
+   org.apache.kafka.common.security.scram.ScramLoginModule required;
+   };
+EOF
+        elif [[ "$internal_protocol" =~ "SASL" ]]; then
+            render-template >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
+KafkaServer {
+   org.apache.kafka.common.security.plain.PlainLoginModule required
+   username="{{KAFKA_INTER_BROKER_USER}}"
+   password="{{KAFKA_INTER_BROKER_PASSWORD}}"
+   user_{{KAFKA_INTER_BROKER_USER}}="{{KAFKA_INTER_BROKER_PASSWORD}}";
+
+   org.apache.kafka.common.security.scram.ScramLoginModule required;
+   };
+EOF
+        fi
+        if [[ -n "$KAFKA_ZOOKEEPER_USER" ]] && [[ -n "$KAFKA_ZOOKEEPER_PASSWORD" ]]; then
+            render-template >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
 Client {
    org.apache.kafka.common.security.plain.PlainLoginModule required
    username="{{KAFKA_ZOOKEEPER_USER}}"
    password="{{KAFKA_ZOOKEEPER_PASSWORD}}";
-};
+   };
 EOF
         fi
     else
         info "Custom JAAS authentication file detected. Skipping generation."
-        warn "The following environment variables will be ignored: KAFKA_BROKER_USER, KAFKA_BROKER_PASSWORD, KAFKA_INTER_BROKER_USER, KAFKA_INTER_BROKER_PASSWORD, KAFKA_ZOOKEEPER_USER and KAFKA_ZOOKEEPER_PASSWORD"
+        warn "The following environment variables will be ignored: KAFKA_CLIENT_USER, KAFKA_CLIENT_PASSWORD, KAFKA_INTER_BROKER_USER, KAFKA_INTER_BROKER_PASSWORD, KAFKA_ZOOKEEPER_USER and KAFKA_ZOOKEEPER_PASSWORD"
     fi
 }
 
 ########################
-# Configure Kafka SSL listener
+# Configure Kafka SSL settings
 # Globals:
 #   KAFKA_CERTIFICATE_PASSWORD
 #   KAFKA_CONF_DIR
@@ -287,14 +340,13 @@ EOF
 # Returns:
 #   None
 #########################
-kafka_configure_ssl_listener() {
+kafka_configure_ssl() {
     # Set Kafka configuration
     kafka_server_conf_set ssl.keystore.location "$KAFKA_CONF_DIR"/certs/kafka.keystore.jks
     kafka_server_conf_set ssl.keystore.password "$KAFKA_CERTIFICATE_PASSWORD"
     kafka_server_conf_set ssl.key.password "$KAFKA_CERTIFICATE_PASSWORD"
     kafka_server_conf_set ssl.truststore.location "$KAFKA_CONF_DIR"/certs/kafka.truststore.jks
     kafka_server_conf_set ssl.truststore.password "$KAFKA_CERTIFICATE_PASSWORD"
-    kafka_server_conf_set ssl.client.auth required
     # Set producer/consumer configuration
     kafka_producer_consumer_conf_set ssl.keystore.location "$KAFKA_CONF_DIR"/certs/kafka.keystore.jks
     kafka_producer_consumer_conf_set ssl.keystore.password "$KAFKA_CERTIFICATE_PASSWORD"
@@ -304,66 +356,75 @@ kafka_configure_ssl_listener() {
 }
 
 ########################
-# Configure Kafka SASL_SSL listener
+# Configure Kafka for inter-broker communications
 # Globals:
-#   KAFKA_CERTIFICATE_PASSWORD
-#   KAFKA_CONF_DIR
-# Arguments:
 #   None
+# Arguments:
+#   $1 - Authentication protocol to use for the internal listener
 # Returns:
 #   None
 #########################
-kafka_configure_sasl_ssl_listener() {
-    info "SASL_SSL listener detected, enabling SASL_SSL settings"
-    kafka_configure_ssl_listener
-    kafka_generate_jaas_authentication_file
-    # Set Kafka configuration
-    kafka_server_conf_set security.inter.broker.protocol SASL_SSL
-    kafka_server_conf_set sasl.mechanism.inter.broker.protocol PLAIN
-    kafka_server_conf_set sasl.enabled.mechanisms PLAIN,SCRAM-SHA-256,SCRAM-SHA-512
-    # Set producer/consumer configuration
-    kafka_producer_consumer_conf_set security.protocol SASL_SSL
-    kafka_producer_consumer_conf_set sasl.mechanism PLAIN
+kafka_configure_internal_communications() {
+    local -r protocol="${1:?missing environment variable protocol}"
+    local -r allowed_protocols=("PLAINTEXT" "SASL_PLAINTEXT" "SASL_SSL" "SSL")
+    info "Configuring Kafka for inter-broker communications with $protocol authentication."
+
+    if [[ " ${allowed_protocols[@]} " =~ " $protocol " ]]; then
+        kafka_server_conf_set security.inter.broker.protocol $protocol
+        if [[ "$protocol" = "PLAINTEXT" ]]; then
+            warn "Inter-broker communications are configured as PLAINTEXT. This is not safe for production environments."
+        fi
+        if [[ "$protocol" = "SASL_PLAINTEXT" ]] || [[ "$protocol" = "SASL_SSL" ]]; then
+            # TODO (juan131): Support other SASL implementations (e.g. GSSAPI)
+            # Please do not confuse SASL/PLAIN with PLAINTEXT (see https://docs.confluent.io/current/kafka/authentication_sasl/authentication_sasl_plain.html#sasl-plain-overview)
+            kafka_server_conf_set sasl.mechanism.inter.broker.protocol PLAIN
+        fi
+        if [[ "$protocol" = "SASL_SSL" ]] || [[ "$protocol" = "SSL" ]]; then
+            kafka_configure_ssl
+            # We need to enable 2 way authentication on SASL_SSL so brokers authenticate each other.
+            # It won't affect client communications unless the SSL protocol is for them.
+            kafka_server_conf_set ssl.client.auth required
+        fi
+    else
+        error "Authentication protocol $protocol is not supported!"
+        exit 1
+    fi
 }
 
 ########################
-# Configure Kafka Only SSL listener
+# Configure Kafka for client communications
 # Globals:
-#   KAFKA_CERTIFICATE_PASSWORD
-#   KAFKA_CONF_DIR
-# Arguments:
 #   None
+# Arguments:
+#   $1 - Authentication protocol to use for the client listener
 # Returns:
 #   None
 #########################
-kafka_configure_only_ssl_listener() {
-    info "SSL listener detected, enabling SSL settings"
-    kafka_configure_ssl_listener
-    # Set Kafka configuration
-    kafka_server_conf_set security.inter.broker.protocol SSL
-    # Set producer/consumer configuration
-    kafka_producer_consumer_conf_set security.protocol SSL
-}
+kafka_configure_client_communications() {
+    local -r protocol="${1:?missing environment variable protocol}"
+    local -r allowed_protocols=("PLAINTEXT" "SASL_PLAINTEXT" "SASL_SSL" "SSL")
+    info "Configuring Kafka for client communications with $protocol authentication."
 
-########################
-# Configure Kafka SASL_PLAINTEXT listener
-# Globals:
-#   KAFKA_CONF_FILE
-# Arguments:
-#   None
-# Returns:
-#   None
-#########################
-kafka_configure_sasl_plaintext_listener() {
-    info "SASL_PLAINTEXT listener detected, enabling SASL_PLAINTEXT settings"
-    kafka_generate_jaas_authentication_file
-    # Set Kafka configuration
-    kafka_server_conf_set sasl.mechanism.inter.broker.protocol PLAIN
-    kafka_server_conf_set sasl.enabled.mechanisms PLAIN,SCRAM-SHA-256,SCRAM-SHA-512
-    kafka_server_conf_set security.inter.broker.protocol SASL_PLAINTEXT
-    # Set producer/consumer configuration
-    kafka_producer_consumer_conf_set security.protocol SASL_PLAINTEXT
-    kafka_producer_consumer_conf_set sasl.mechanism PLAIN
+    if [[ " ${allowed_protocols[@]} " =~ " $protocol " ]]; then
+        kafka_server_conf_set security.inter.broker.protocol $protocol
+        if [[ "$protocol" = "PLAINTEXT" ]]; then
+            warn "Client communications are configured as PLAINTEXT. This is not safe for production environments."
+        fi
+        if [[ "$protocol" = "SASL_PLAINTEXT" ]] || [[ "$protocol" = "SASL_SSL" ]]; then
+            # TODO (juan131): Support other SASL implementations (e.g. GSSAPI)
+            # Please do not confuse SASL/PLAIN with PLAINTEXT (see https://docs.confluent.io/current/kafka/authentication_sasl/authentication_sasl_plain.html#sasl-plain-overview)
+            kafka_server_conf_set sasl.mechanism.inter.broker.protocol PLAIN
+        fi
+        if [[ "$protocol" = "SASL_SSL" ]] || [[ "$protocol" = "SSL" ]]; then
+            kafka_configure_ssl
+        fi
+        if [[ "$protocol" = "SSL" ]]; then
+            kafka_server_conf_set ssl.client.auth required
+        fi
+    else
+        error "Authentication protocol $protocol is not supported!"
+        exit 1
+    fi
 }
 
 ########################
@@ -409,16 +470,28 @@ kafka_initialize() {
         info "No injected configuration files found, creating default config files"
         kafka_server_conf_set log.dirs "$KAFKA_DATA_DIR"
         kafka_configure_from_environment_variables
-        if [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL_SSL ]] || [[ "${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-}" =~ SASL_SSL ]]; then
-            kafka_configure_sasl_ssl_listener
-        elif [[ "${KAFKA_CFG_LISTENERS:-}" =~ SSL ]] || [[ "${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-}" =~ SSL ]]; then
-            kafka_configure_only_ssl_listener
-        elif [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL_PLAINTEXT ]] || [[ "${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-}" =~ SASL_PLAINTEXT ]]; then
-            kafka_configure_sasl_plaintext_listener
+        # When setting up a Kafka cluster with N brokers, we have several listeners:
+        # - INTERNAL: used for inter-broker communications
+        # - CLIENT: used for communications with consumers/producers within the same network
+        # - (optional) EXTERNAL: used for communications with consumers/producers on different networks
+        local internal_protocol
+        local client_protocol
+        if [[ ${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-} = *"INTERNAL"* ]] || [[ ${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-} = *"CLIENT"* ]]; then
+            if [[ ${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-} =~ INTERNAL:([a-zA-Z_]*) ]]; then
+                internal_protocol="${BASH_REMATCH[1]}"
+                kafka_configure_internal_communications "$internal_protocol"
+            fi
+            if [[ ${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-} =~ CLIENT:([a-zA-Z_]*) ]]; then
+                client_protocol="${BASH_REMATCH[1]}"
+                kafka_configure_client_communications "$client_protocol"
+            fi
         fi
-
+        if [[ "${internal_protocol:-}" =~ "SASL" ]] || [[ "${client_protocol:-}" =~ "SASL" ]] || [[ -n "$KAFKA_ZOOKEEPER_USER" && -n "$KAFKA_ZOOKEEPER_PASSWORD" ]]; then
+            kafka_server_conf_set sasl.enabled.mechanisms PLAIN,SCRAM-SHA-256,SCRAM-SHA-512
+            kafka_generate_jaas_authentication_file "$internal_protocol" "$client_protocol"
+        fi
         # Remove security.inter.broker.protocol if KAFKA_CFG_INTER_BROKER_LISTENER_NAME is configured
-        if [[ ! -z "${KAFKA_CFG_INTER_BROKER_LISTENER_NAME:-}" ]]; then
+        if [[ -n "${KAFKA_CFG_INTER_BROKER_LISTENER_NAME:-}" ]]; then
             remove_in_file "$KAFKA_CONF_FILE" "security.inter.broker.protocol" false
         fi
     fi

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -229,13 +229,13 @@ kafka_validate() {
 
     if [[ ${KAFKA_CFG_LISTENERS:-} =~ INTERNAL:\/\/:([0-9]*) ]]; then
         internal_port="${BASH_REMATCH[1]}"
-        check_allowed_port "$internal_port"
+        check_allowed_listener_port "$internal_port"
     fi
     if [[ ${KAFKA_CFG_LISTENERS:-} =~ CLIENT:\/\/:([0-9]*) ]]; then
         client_port="${BASH_REMATCH[1]}"
-        check_allowed_port "$client_port"
+        check_allowed_listener_port "$client_port"
     fi
-    [[ -n ${internal_port:-} && -n ${client_port:-} ]] && check_conflicting_ports "$internal_port" "$client_port"
+    [[ -n ${internal_port:-} && -n ${client_port:-} ]] && check_conflicting_listener_ports "$internal_port" "$client_port"
     if [[ -n "${KAFKA_PORT_NUMBER:-}" ]] || [[ -n "${KAFKA_CFG_PORT:-}" ]]; then
         warn "The environment variables KAFKA_PORT_NUMBER and KAFKA_CFG_PORT are deprecated, you can specify the port number to use for each listener using the KAFKA_CFG_LISTENERS environment variable instead."
     fi

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -209,7 +209,7 @@ kafka_validate() {
         error "$1"
         error_code=1
     }
-    check_conflicting_ports() {
+    check_allowed_listener_port() {
         local -r total="$#"
         for i in $(seq 1 "$((total - 1))"); do
             for j in $(seq "$((i + 1))" "$total"); do
@@ -219,7 +219,7 @@ kafka_validate() {
             done
         done
     }
-    check_allowed_port() {
+    check_conflicting_listener_ports() {
         local validate_port_args=()
         ! am_i_root && validate_port_args+=("-unprivileged")
         if ! err=$(validate_port "${validate_port_args[@]}" "$1"); then

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -227,15 +227,15 @@ kafka_validate() {
         fi
     }
 
-    if [[ ${KAFKA_CFG_LISTENERS:-} =~ INTERNAL:\/\/:([0-9]*) ]]; then
+    if [[ "${KAFKA_CFG_LISTENERS:-}" =~ INTERNAL:\/\/:([0-9]*) ]]; then
         internal_port="${BASH_REMATCH[1]}"
         check_allowed_listener_port "$internal_port"
     fi
-    if [[ ${KAFKA_CFG_LISTENERS:-} =~ CLIENT:\/\/:([0-9]*) ]]; then
+    if [[ "${KAFKA_CFG_LISTENERS:-}" =~ CLIENT:\/\/:([0-9]*) ]]; then
         client_port="${BASH_REMATCH[1]}"
         check_allowed_listener_port "$client_port"
     fi
-    [[ -n ${internal_port:-} && -n ${client_port:-} ]] && check_conflicting_listener_ports "$internal_port" "$client_port"
+    [[ -n "${internal_port:-}" && -n "${client_port:-}" ]] && check_conflicting_listener_ports "$internal_port" "$client_port"
     if [[ -n "${KAFKA_PORT_NUMBER:-}" ]] || [[ -n "${KAFKA_CFG_PORT:-}" ]]; then
         warn "The environment variables KAFKA_PORT_NUMBER and KAFKA_CFG_PORT are deprecated, you can specify the port number to use for each listener using the KAFKA_CFG_LISTENERS environment variable instead."
     fi
@@ -372,7 +372,7 @@ kafka_configure_internal_communications() {
     local -r allowed_protocols=("PLAINTEXT" "SASL_PLAINTEXT" "SASL_SSL" "SSL")
     info "Configuring Kafka for inter-broker communications with ${protocol} authentication."
 
-    if [[ " ${allowed_protocols[@]} " =~ " ${protocol} " ]]; then
+    if [[ " ${allowed_protocols[*]} " =~ " ${protocol} " ]]; then
         kafka_server_conf_set security.inter.broker.protocol "$protocol"
         if [[ "$protocol" = "PLAINTEXT" ]]; then
             warn "Inter-broker communications are configured as PLAINTEXT. This is not safe for production environments."
@@ -409,7 +409,7 @@ kafka_configure_client_communications() {
     local -r allowed_protocols=("PLAINTEXT" "SASL_PLAINTEXT" "SASL_SSL" "SSL")
     info "Configuring Kafka for client communications with ${protocol} authentication."
 
-    if [[ " ${allowed_protocols[@]} " =~ " ${protocol} " ]]; then
+    if [[ " ${allowed_protocols[*]} " =~ " ${protocol} " ]]; then
         kafka_server_conf_set security.inter.broker.protocol "$protocol"
         if [[ "$protocol" = "PLAINTEXT" ]]; then
             warn "Client communications are configured using PLAINTEXT listeners. For safety reasons, do not use this in a production environment."

--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ $ docker-compose up kafka
 
 ### 2.5.0-debian-10-r51
 
-* The environment variable `KAFKA_CFG_PORT` was deprecated, use `KAFKA_CFG_LISTENERS` instead.
+* The environment variables `KAFKA_PORT_NUMBER` and `KAFKA_CFG_PORT` was deprecated, you can specify the port number in `KAFKA_CFG_LISTENERS` instead.
 * The following environment variables were renamed:
 
   * `KAFKA_BROKER_USER` -> `KAFKA_CLIENT_USER`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # What is Kafka?
 
 Apache Kafka is a distributed streaming platform used for building real-time data pipelines and
@@ -7,7 +6,7 @@ thousands of companies. Kafka requires a connection to a Zookeeper service.
 
 [https://kafka.apache.org/](https://kafka.apache.org/)
 
-# TL;DR;
+## TL;DR;
 
 ## Run the application using Docker Compose
 
@@ -18,7 +17,7 @@ $ curl -sSL https://raw.githubusercontent.com/bitnami/bitnami-docker-kafka/maste
 $ docker-compose up -d
 ```
 
-# Why use Bitnami Images?
+## Why use Bitnami Images?
 
 * Bitnami closely tracks upstream source changes and promptly publishes new versions of this image using our automated systems.
 * With Bitnami images the latest bug fixes and features are available as soon as possible.
@@ -27,29 +26,27 @@ $ docker-compose up -d
 * All Bitnami images available in Docker Hub are signed with [Docker Content Trust (DTC)](https://docs.docker.com/engine/security/trust/content_trust/). You can use `DOCKER_CONTENT_TRUST=1` to verify the integrity of the images.
 * Bitnami container images are released daily with the latest distribution packages available.
 
-
 > This [CVE scan report](https://quay.io/repository/bitnami/kafka?tab=tags) contains a security report with all open CVEs. To get the list of actionable security issues, find the "latest" tag, click the vulnerability report link under the corresponding "Security scan" field and then select the "Only show fixable" filter on the next page.
 
-# How to deploy Apache Kafka in Kubernetes?
+## How to deploy Apache Kafka in Kubernetes?
 
 Deploying Bitnami applications as Helm Charts is the easiest way to get started with our applications on Kubernetes. Read more about the installation in the [Bitnami Apache Kafka Chart GitHub repository](https://github.com/bitnami/charts/tree/master/bitnami/kafka).
 
 Bitnami containers can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters.
 
-# Why use a non-root container?
+## Why use a non-root container?
 
 Non-root container images add an extra layer of security and are generally recommended for production environments. However, because they run as a non-root user, privileged tasks are typically off-limits. Learn more about non-root containers [in our docs](https://docs.bitnami.com/tutorials/work-with-non-root-containers/).
 
-# Supported tags and respective `Dockerfile` links
+## Supported tags and respective `Dockerfile` links
 
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
-
 
 * [`2-debian-10`, `2.5.0-debian-10-r50`, `2`, `2.5.0`, `latest` (2/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-kafka/blob/2.5.0-debian-10-r50/2/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/kafka GitHub repo](https://github.com/bitnami/bitnami-docker-kafka).
 
-# Get this image
+## Get this image
 
 The recommended way to get the Bitnami Kafka Docker Image is to pull the prebuilt image from the [Docker Hub Registry](https://hub.docker.com/r/bitnami/kafka).
 
@@ -71,13 +68,11 @@ If you wish, you can also build the image yourself.
 docker build -t bitnami/kafka:latest 'https://github.com/bitnami/bitnami-docker-kafka.git#master:2/debian-10'
 ```
 
-# Persisting your data
+## Persisting your data
 
 If you remove the container all your data and configurations will be lost, and the next time you run the image the database will be reinitialized. To avoid this loss of data, you should mount a volume that will persist even after the container is removed.
 
-**Note!**
-If you have already started using your database, follow the steps on
-[backing up](#backing-up-your-container) and [restoring](#restoring-a-backup) to pull the data from your running container down to your host.
+> Note: If you have already started using your database, follow the steps on [backing up](#backing-up-your-container) and [restoring](#restoring-a-backup) to pull the data from your running container down to your host.
 
 The image exposes a volume at `/bitnami/kafka` for the Kafka data. For persistence you can mount a directory at this location from your host. If the mounted directory is empty, it will be initialized on the first run.
 
@@ -95,23 +90,23 @@ kafka:
 
 > NOTE: As this is a non-root container, the mounted files and directories must have the proper permissions for the UID `1001`.
 
-# Connecting to other containers
+## Connecting to other containers
 
 Using [Docker container networking](https://docs.docker.com/engine/userguide/networking/), a Kafka server running inside a container can easily be accessed by your application containers.
 
 Containers attached to the same network can communicate with each other using the container name as the hostname.
 
-## Using the Command Line
+### Using the Command Line
 
 In this example, we will create a Kafka client instance that will connect to the server instance that is running on the same docker network as the client.
 
-### Step 1: Create a network
+#### Step 1: Create a network
 
 ```console
 $ docker network create app-tier --driver bridge
 ```
 
-### Step 2: Launch the Zookeeper server instance
+#### Step 2: Launch the Zookeeper server instance
 
 Use the `--network app-tier` argument to the `docker run` command to attach the Zookeeper container to the `app-tier` network.
 
@@ -122,7 +117,7 @@ $ docker run -d --name zookeeper-server \
     bitnami/zookeeper:latest
 ```
 
-### Step 2: Launch the Kafka server instance
+#### Step 2: Launch the Kafka server instance
 
 Use the `--network app-tier` argument to the `docker run` command to attach the Kafka container to the `app-tier` network.
 
@@ -134,7 +129,7 @@ $ docker run -d --name kafka-server \
     bitnami/kafka:latest
 ```
 
-### Step 3: Launch your Kafka client instance
+#### Step 3: Launch your Kafka client instance
 
 Finally we create a new container instance to launch the Kafka client and connect to the server created in the previous step:
 
@@ -145,7 +140,7 @@ $ docker run -it --rm \
     bitnami/kafka:latest kafka-topics.sh --list  --zookeeper zookeeper-server:2181
 ```
 
-## Using Docker Compose
+### Using Docker Compose
 
 When not specified, Docker Compose automatically sets up a new network and attaches all deployed services to that network. However, we will explicitly define a new `bridge` network named `app-tier`. In this example we assume that you want to connect to the Kafka server from your own custom application image which is identified in the following snippet by the service name `myapp`.
 
@@ -183,19 +178,19 @@ Launch the containers using:
 $ docker-compose up -d
 ```
 
-# Configuration
+## Configuration
 
 The configuration can easily be setup with the Bitnami Kafka Docker image using the following environment variables:
 
-- `ALLOW_PLAINTEXT_LISTENER`: Allow to use the PLAINTEXT listener. Default: **no**
-- `KAFKA_INTER_BROKER_USER`: Kafka inter broker communication user. Default: admin. Default: **user**
-- `KAFKA_INTER_BROKER_PASSWORD`: Kafka inter broker communication password. Default: **bitnami**
-- `KAFKA_BROKER_USER`: Kafka client user. Default: **user**
-- `KAFKA_BROKER_PASSWORD`: Kafka client user password. Default: **bitnami**
-- `KAFKA_ZOOKEEPER_USER`: Kafka Zookeeper user. No defaults
-- `KAFKA_ZOOKEEPER_PASSWORD`: Kafka Zookeeper user password. No defaults
-- `KAFKA_CERTIFICATE_PASSWORD`: Password for certificates. No defaults.
-- `KAFKA_HEAP_OPTS`: Kafka's Java Heap size. Default: **-Xmx1024m -Xms1024m**
+* `ALLOW_PLAINTEXT_LISTENER`: Allow to use the PLAINTEXT listener. Default: **no**
+* `KAFKA_INTER_BROKER_USER`: Kafka inter broker communication user. Default: admin. Default: **user**
+* `KAFKA_INTER_BROKER_PASSWORD`: Kafka inter broker communication password. Default: **bitnami**
+* `KAFKA_CLIENT_USER`: Kafka client user. Default: **user**
+* `KAFKA_CLIENT_PASSWORD`: Kafka client user password. Default: **bitnami**
+* `KAFKA_ZOOKEEPER_USER`: Kafka Zookeeper user. No defaults
+* `KAFKA_ZOOKEEPER_PASSWORD`: Kafka Zookeeper user password. No defaults
+* `KAFKA_CERTIFICATE_PASSWORD`: Password for certificates. No defaults.
+* `KAFKA_HEAP_OPTS`: Kafka's Java Heap size. Default: **-Xmx1024m -Xms1024m**
 
 Additionally, any environment variable beginning with `KAFKA_CFG_` will be mapped to its corresponding Kafka key. For example, use `KAFKA_CFG_BACKGROUND_THREADS` in order to set `background.threads` or `KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE` in order to configure `auto.create.topics.enable`.
 
@@ -213,7 +208,7 @@ kafka:
   ...
 ```
 
-## Accessing Kafka with internal and external clients
+### Accessing Kafka with internal and external clients
 
 In order to use internal and external clients to access Kafka brokers you need to configure one listener for each kind of clients.
 
@@ -223,9 +218,9 @@ To do so, add the following environment variables to your docker-compose:
     environment:
       - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
       - ALLOW_PLAINTEXT_LISTENER=yes
-+     - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-+     - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,PLAINTEXT_HOST://:29092
-+     - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
++     - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
++     - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
++     - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://localhost:9093
 ```
 
 And expose the extra port:
@@ -233,63 +228,71 @@ And expose the extra port:
 ```diff
     ports:
       - '9092:9092'
-+     - '29092:29092'
++     - '9093:9093'
 ```
 
-### Producer and consumer using internal client
+#### Producer and consumer using internal client
+
+These clients will use localhost to connect to Kafka.
+
+```console
+kafka-console-producer.sh --broker-list 127.0.0.1:9092 --topic test
+kafka-console-consumer.sh --bootstrap-server 127.0.0.1:9092 --topic test --from-beginning
+```
+
+#### Producer and consumer using external client
 
 These clients will use the docker hostname to connect to Kafka.
 
 ```console
-kafka-console-producer.sh --broker-list kafka:9092 --topic test
-kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic test --from-beginning
-```
-
-### Producer and consumer using external client
-
-These clients will use the localhost listener created in the port 29092 to connect to Kafka.
-
-```console
-kafka-console-producer.sh --broker-list localhost:29092 --topic test
-kafka-console-consumer.sh --bootstrap-server localhost:29092 --topic test --from-beginning
+kafka-console-producer.sh --broker-list kafka:9093 --topic test
+kafka-console-consumer.sh --bootstrap-server kafka:9093 --topic test --from-beginning
 ```
 
 More info about Kafka listeners can be found in [this great article](https://rmoff.net/2018/08/02/kafka-listeners-explained/)
 
-## Security
+### Security
 
-The Bitnami Kafka docker image disables the PLAINTEXT listener for security reasons.
-You can enable the PLAINTEXT listener by adding the next environment variable, but remember that this
-configuration is not recommended for production.
+The Bitnami Kafka docker image disables the PLAINTEXT listener for security reasons. You can enable the PLAINTEXT listener by adding the next environment variable, but remember that this configuration is not recommended for production.
 
 ```console
 ALLOW_PLAINTEXT_LISTENER=yes
 ```
 
-In order to configure SASL authentication over SSL, you should define the proper listener by
-passing the following env vars:
+In order to configure authentication, you must configure the Kafka listeners properly. This container assumes the names below will be used for the listeners:
+
+* INTERNAL: used for inter-broker communications.
+* CLIENT: used for coummunications with clients that are within the same network as Kafka brokers.
+* EXTERNAL: used for communications with clients that are on a different network.
+
+Let's see an example to configure Kafka with `SASL_SSL` authentication for communications with clients, and `SSL` authentication for inter-broker communication.
+
+The environment variables below should be define to configure the listeners, and the SASL credentials for client communications:
 
 ```console
-KAFKA_CFG_LISTENERS=SASL_SSL://:9092
-KAFKA_CFG_ADVERTISED_LISTENERS=SASL_SSL://:9092
+KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:SSL,CLIENT:SASL_SSL
+KAFKA_CFG_LISTENERS=INTERNAL://:9093,CLIENT://:9092
+KAFKA_CFG_ADVERTISED_LISTENERS=INTERNAL://kafka:9093,CLIENT://kafka:9092
+KAFKA_CLIENT_USER=user
+KAFKA_CLIENT_PASSWORD=password
 ```
 
-You **must** also use your own certificates for SSL. You can drop your Java Key Stores files into `/opt/bitnami/kafka/conf/certs`.
-If the JKS is password protected (recommended), you will need to provide it to get access to the keystores:
+You **must** also use your own certificates for SSL. You can drop your Java Key Stores files into `/opt/bitnami/kafka/conf/certs`. If the JKS is password protected (recommended), you will need to provide it to get access to the keystores:
 
 `KAFKA_CERTIFICATE_PASSWORD=myCertificatePassword`
 
 The following script can help you with the creation of the JKS and certificates:
 
-https://raw.githubusercontent.com/confluentinc/confluent-platform-security-tools/master/kafka-generate-ssl.sh
+* [kafka-generate-ssl.sh](https://raw.githubusercontent.com/confluentinc/confluent-platform-security-tools/master/kafka-generate-ssl.sh)
 
 Keep in mind the following notes:
 
 * When prompted to enter a password, use the same one for all.
 * Set the Common Name or FQDN values to your Kafka container hostname, e.g. `kafka.example.com`. After entering this value, when prompted "What is your first and last name?", enter this value as well.
+  * As an alternative, you can disable host name verification setting the environment variable `KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM` to an empty string.
+* When setting up a Kafka Cluster (check [this section](#setting-up-a-kafka-cluster) for more information), each Kafka broker and logical client needs its own keystore. You will have to repeat the process for each of the brokers in the cluster.
 
-The following docker-compose file is an example showing how to mount your JKS certificates protected by the password `certificatePassword123`.
-Additionally it is specifying the Kafka container hostname and the credentials for the broker, inter-broker and zookeeper users.
+The following docker-compose file is an example showing how to mount your JKS certificates protected by the password `certificatePassword123`. Additionally it is specifying the Kafka container hostname and the credentials for the client and zookeeper users.
 
 ```yaml
 version: '2'
@@ -314,93 +317,57 @@ services:
       - KAFKA_CFG_ADVERTISED_LISTENERS=SASL_SSL://:9092
       - KAFKA_ZOOKEEPER_USER=kafka
       - KAFKA_ZOOKEEPER_PASSWORD=kafka_password
-      - KAFKA_INTER_BROKER_USER=interuser
-      - KAFKA_INTER_BROKER_PASSWORD=interpassword
-      - KAFKA_BROKER_USER=user
-      - KAFKA_BROKER_PASSWORD=password
+      - KAFKA_CLIENT_USER=user
+      - KAFKA_CLIENT_PASSWORD=password
       - KAFKA_CERTIFICATE_PASSWORD=certificatePassword123
     volumes:
       - './kafka.keystore.jks:/opt/bitnami/kafka/conf/certs/kafka.keystore.jks:ro'
       - './kafka.truststore.jks:/opt/bitnami/kafka/conf/certs/kafka.truststore.jks:ro'
 ```
 
-### InterBroker communications
+In order to get the required credentials to consume and produce messages you need to provide the credentials in the client. If your Kafka client allows it, use the credentials you've provided.
 
-By default, communications that happens between brokers are authenticated.
-You can provide your own credentials using this environment variables:
+While producing and consuming messages using the `bitnami/kafka` image, you'll need to point to the `consumer.properties` and/or `producer.properties` file, which contains the needed configuration
+to work. You can find this files in the `/opt/bitnami/kafka/conf` directory.
 
-
-- `KAFKA_INTER_BROKER_USER`: Kafka inter broker communication user. Default: **user**
-- `KAFKA_INTER_BROKER_PASSWORD`: Kafka inter broker communication password. Default: **bitnami**
-
-### Kafka client configuration
-
-By default, any Kafka client needs to authenticate before can connect to a broker.
-You can provide your own credentials using this environment variables:
-
-- `KAFKA_BROKER_USER`: Kafka client user. Default: **user**
-- `KAFKA_BROKER_PASSWORD`: Kafka client user password. Default: **bitnami**
-
-### Kafka ZooKeeper client configuration
-
-In order to authenticate Kafka against a Zookeeper server with SASL authentication you should provide
-the next environment variables:
-
-- `KAFKA_ZOOKEEPER_USER`: Kafka Zookeeper user. No defaults.
-- `KAFKA_ZOOKEEPER_PASSWORD`: Kafka Zookeeper user password. No defaults.
-
-Below you can see a complete Docker Compose example:
-
-
-```yaml
-version: '2'
-
-services:
-  zookeeper:
-    image: 'bitnami/zookeeper:latest'
-    ports:
-     - '2181:2181'
-    environment:
-      - ZOO_ENABLE_AUTH=yes
-      - ZOO_SERVER_USERS=kafka
-      - ZOO_SERVER_PASSWORDS=kafka_password
-  kafka:
-    image: 'bitnami/kafka:latest'
-    ports:
-      - '9092'
-    environment:
-      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
-      - KAFKA_CFG_LISTENERS=SASL_SSL://:9092
-      - KAFKA_CFG_ADVERTISED_LISTENERS=SASL_SSL://:9092
-      - KAFKA_ZOOKEEPER_USER=kafka
-      - KAFKA_ZOOKEEPER_PASSWORD=kafka_password
-```
-
-### Connecting services with security enabled
-
-In order to get the required credentials to consume and  produce messages you need to provide the
-credentials in the client. If your Kafka client allows it, use the credentials you've provided.
-
-While producing and consuming messages using the `bitnami/kafka` image, you'll need to point to the
-`consumer.properties` and/or `producer.properties` file, which contains the needed configuration
-to work. You can find this files in the `/opt/bitnami/kafka/conf` directory
-
-Use this to generate messages using a secure setup
+Use this to generate messages using a secure setup:
 
 ```console
 export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/bitnami/kafka/conf/kafka_jaas.conf"
 kafka-console-producer.sh --broker-list 127.0.0.1:9092 --topic test --producer.config /opt/bitnami/kafka/conf/producer.properties
 ```
+
 Use this to consume messages using a secure setup
 
 ```console
 export KAFKA_OPTS="-Djava.security.auth.login.config=/opt/bitnami/kafka/conf/kafka_jaas.conf"
 kafka-console-consumer.sh --bootstrap-server 127.0.0.1:9092 --topic test --consumer.config /opt/bitnami/kafka/conf/consumer.properties
 ```
-If you use other tools to use your Kafka cluster, you'll need to provide the required information.
-You can find the required information in the files located at `/opt/bitnami/kafka/conf` directory.
 
-## Setting up a Kafka Cluster
+If you use other tools to use your Kafka cluster, you'll need to provide the required information. You can find the required information in the files located at `/opt/bitnami/kafka/conf` directory.
+
+#### InterBroker communications
+
+When configuring your broker to use `SASL` or `SASL_SSL` for inter-broker communications, you can provide the SASL credentials using these environment variables:
+
+* `KAFKA_INTER_BROKER_USER`: Kafka inter broker communication user. Default: **user**
+* `KAFKA_INTER_BROKER_PASSWORD`: Kafka inter broker communication password. Default: **bitnami**
+
+#### Kafka client configuration
+
+When configuring Kafka with `SASL` or `SASL_SSL` for communications with clients, you can provide your the SASL credentials using this environment variables:
+
+* `KAFKA_CLIENT_USER`: Kafka client user. Default: **user**
+* `KAFKA_CLIENT_PASSWORD`: Kafka client user password. Default: **bitnami**
+
+#### Kafka ZooKeeper client configuration
+
+In order to authenticate Kafka against a Zookeeper server with `SASL` or `SASL_SSL` authentication you should provide the environment variables below:
+
+* `KAFKA_ZOOKEEPER_USER`: Kafka Zookeeper user. No defaults.
+* `KAFKA_ZOOKEEPER_PASSWORD`: Kafka Zookeeper user password. No defaults.
+
+### Setting up a Kafka Cluster
 
 A Kafka cluster can easily be setup with the Bitnami Kafka Docker image using the following environment variables:
 
@@ -412,7 +379,7 @@ Create a Docker network to enable visibility to each other via the docker contai
 $ docker network create app-tier --driver bridge
 ```
 
-### Step 1: Create the first node for Zookeeper
+#### Step 1: Create the first node for Zookeeper
 
 The first step is to create one Zookeeper instance.
 
@@ -424,7 +391,7 @@ $ docker run --name zookeeper \
   bitnami/zookeeper:latest
 ```
 
-### Step 2: Create the first node for Kafka
+#### Step 2: Create the first node for Kafka
 
 The first step is to create one Kafka instance.
 
@@ -437,7 +404,7 @@ $ docker run --name kafka1 \
   bitnami/kafka:latest
 ```
 
-### Step 2: Create the second node
+#### Step 2: Create the second node
 
 Next we start a new Kafka container.
 
@@ -462,6 +429,7 @@ $ docker run --name kafka3 \
   -p 9092:9092 \
   bitnami/kafka:latest
 ```
+
 You now have a Kafka cluster up and running. You can scale the cluster by adding/removing slaves without incurring any downtime.
 
 With Docker Compose, topic replication can be setup using:
@@ -512,7 +480,7 @@ Topic:mytopic   PartitionCount:3        ReplicationFactor:3     Configs:
         Topic: mytopic  Partition: 2    Leader: 1       Replicas: 1,2,3 Isr: 1,2,3
 ```
 
-## Full configuration
+### Full configuration
 
 The image looks for configuration files (server.properties, log4j.properties, etc.) in the `/bitnami/kafka/config/` directory, this directory can be changed by setting the KAFKA_MOUNTED_CONF_DIR environment variable.
 
@@ -522,7 +490,7 @@ $ docker run --name kafka -v /path/to/server.properties:/bitnami/kafka/conf/serv
 
 After that, your changes will be taken into account in the server's behaviour.
 
-### Step 1: Run the Kafka image
+#### Step 1: Run the Kafka image
 
 Run the Kafka image, mounting a directory from your host.
 
@@ -538,7 +506,7 @@ services:
 +     - /path/to/server.properties:/bitnami/kafka/conf/server.properties
 ```
 
-### Step 2: Edit the configuration
+#### Step 2: Edit the configuration
 
 Edit the configuration on your host using your favorite editor.
 
@@ -546,7 +514,7 @@ Edit the configuration on your host using your favorite editor.
 vi /path/to/server.properties
 ```
 
-### Step 3: Restart Kafka
+#### Step 3: Restart Kafka
 
 After changing the configuration, restart your Kafka container for changes to take effect.
 
@@ -560,7 +528,7 @@ Or using Docker Compose:
 $ docker-compose restart kafka
 ```
 
-# Logging
+## Logging
 
 The Bitnami Kafka Docker image sends the container logs to the `stdout`. To view the logs:
 
@@ -576,13 +544,13 @@ $ docker-compose logs kafka
 
 You can configure the containers [logging driver](https://docs.docker.com/engine/admin/logging/overview/) using the `--log-driver` option if you wish to consume the container logs differently. In the default configuration docker uses the `json-file` driver.
 
-# Maintenance
+## Maintenance
 
-## Backing up your container
+### Backing up your container
 
 To backup your data, configuration and logs, follow these simple steps:
 
-### Step 1: Stop the currently running container
+#### Step 1: Stop the currently running container
 
 ```console
 $ docker stop kafka
@@ -594,7 +562,7 @@ Or using Docker Compose:
 $ docker-compose stop kafka
 ```
 
-### Step 2: Run the backup command
+#### Step 2: Run the backup command
 
 We need to mount two volumes in a container we will use to create the backup: a directory on your host to store the backup in, and the volumes from the container we just stopped so we can access the data.
 
@@ -610,7 +578,7 @@ $ docker run --rm -v /path/to/kafka-backups:/backups --volumes-from `docker-comp
   cp -a /bitnami/kafka:latest /backups/latest
 ```
 
-## Restoring a backup
+### Restoring a backup
 
 Restoring a backup is as simple as mounting the backup as volumes in the container.
 
@@ -626,11 +594,11 @@ kafka:
     - /path/to/kafka-backups/latest:/bitnami/kafka
 ```
 
-## Upgrade this image
+### Upgrade this image
 
 Bitnami provides up-to-date versions of Kafka, including security patches, soon after they are made upstream. We recommend that you follow these steps to upgrade your container.
 
-### Step 1: Get the updated image
+#### Step 1: Get the updated image
 
 ```console
 $ docker pull bitnami/kafka:latest
@@ -639,13 +607,13 @@ $ docker pull bitnami/kafka:latest
 or if you're using Docker Compose, update the value of the image property to
 `bitnami/kafka:latest`.
 
-### Step 2: Stop and backup the currently running container
+#### Step 2: Stop and backup the currently running container
 
 Before continuing, you should backup your container's data, configuration and logs.
 
 Follow the steps on [creating a backup](#backing-up-your-container).
 
-### Step 3: Remove the currently running container
+#### Step 3: Remove the currently running container
 
 ```console
 $ docker rm -v kafka
@@ -658,7 +626,7 @@ Or using Docker Compose:
 $ docker-compose rm -v kafka
 ```
 
-### Step 4: Run the new image
+#### Step 4: Run the new image
 
 Re-create your container from the new image, [restoring your backup](#restoring-a-backup) if necessary.
 
@@ -672,89 +640,99 @@ Or using Docker Compose:
 $ docker-compose up kafka
 ```
 
-# Notable Changes
+## Notable Changes
 
-## 2.4.1-r38-debian-10
+### 2.5.0-debian-10-r51
 
-- The configuration directory was changed to `/opt/bitnami/kafka/config`. Configuration files should be mounted to `/bitnami/kafka/config`.
+* The environment variable `KAFKA_CFG_PORT` was deprecated, use `KAFKA_CFG_LISTENERS` instead.
+* The following environment variables were renamed:
 
-## 1.1.1-debian-9-r224, 2.2.1-debian-9-r16, 1.1.1-ol-7-r306 and 2.2.1-ol-7-r14
+  * `KAFKA_BROKER_USER` -> `KAFKA_CLIENT_USER`
+  * `KAFKA_BROKER_PASSWORD` -> `KAFKA_CLIENT_PASSWORD`
 
-- The following environment variables were beingly wrongly translated into `KAFKA_CFG_` environment variables, and therefore they were being wrongly mapped into Kafka keys:
+* Listeners & advertised listeners must be configured to enable authentication. Check [Security section](#security) for more information.
 
-  - `KAFKA_LOGS_DIRS` -> `KAFKA_CFG_LOG_DIRS`
-  - `KAFKA_PORT_NUMBER` -> `KAFKA_CFG_PORT`
-  - `KAFKA_ZOOKEEPER_CONNECT_TIMEOUT_MS` -> `KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS`
+### 2.4.1-r38-debian-10
 
-- For consistency reasons with previous environment variables, the following `KAFKA_` to `KAFKA_CFG_` environment variable translations are now supported for mapping into Kafka keys:
+The configuration directory was changed to `/opt/bitnami/kafka/config`. Configuration files should be mounted to `/bitnami/kafka/config`.
 
-  - `KAFKA_LOG_DIRS` -> `KAFKA_CFG_LOG_DIRS`
-  - `KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS` -> `KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS`
+### 1.1.1-debian-9-r224, 2.2.1-debian-9-r16, 1.1.1-ol-7-r306 and 2.2.1-ol-7-r14
 
-## 1.1.1-debian-9-r205, 2.2.0-debian-9-r40, 1.1.1-ol-7-r286, and 2.2.0-ol-7-r53
+* The following environment variables were beingly wrongly translated into `KAFKA_CFG_` environment variables, and therefore they were being wrongly mapped into Kafka keys:
 
-- Configuration changes. Most environment variables now start with `KAFKA_CFG_`, as they are now mapped directly to Kafka keys. Variables changed:
-   - `KAFKA_ADVERTISED_LISTENERS` -> `KAFKA_CFG_ADVERTISED_LISTENERS`
-   - `KAFKA_BROKER_ID` -> `KAFKA_CFG_BROKER_ID`
-   - `KAFKA_DEFAULT_REPLICATION_FACTOR` -> `KAFKA_CFG_DEFAULT_REPLICATION_FACTOR`
-   - `KAFKA_DELETE_TOPIC_ENABLE` -> `KAFKA_CFG_DELETE_TOPIC_ENABLE`
-   - `KAFKA_INTER_BROKER_LISTENER_NAME` -> `KAFKA_CFG_INTER_BROKER_LISTENER_NAME`
-   - `KAFKA_LISTENERS` -> `KAFKA_CFG_LISTENERS`
-   - `KAFKA_LISTENER_SECURITY_PROTOCOL_MAP` -> `KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP`
-   - `KAFKA_LOGS_DIRS` -> `KAFKA_CFG_LOG_DIRS`
-   - `KAFKA_LOG_FLUSH_INTERVAL_MESSAGES` -> `KAFKA_CFG_LOG_FLUSH_INTERVAL_MESSAGES`
-   - `KAFKA_LOG_FLUSH_INTERVAL_MS` -> `KAFKA_CFG_LOG_FLUSH_INTERVAL_MS`
-   - `KAFKA_LOG_MESSAGE_FORMAT_VERSION` -> `KAFKA_CFG_LOG_MESSAGE_FORMAT_VERSION`
-   - `KAFKA_LOG_RETENTION_BYTES` -> `KAFKA_CFG_LOG_RETENTION_BYTES`
-   - `KAFKA_LOG_RETENTION_CHECK_INTERVALS_MS` -> `KAFKA_CFG_LOG_RETENTION_CHECK_INTERVAL_MS`
-   - `KAFKA_LOG_RETENTION_HOURS` -> `KAFKA_CFG_LOG_RETENTION_HOURS`
-   - `KAFKA_MAX_MESSAGE_BYTES` -> `KAFKA_CFG_MESSAGE_MAX_BYTES`
-   - `KAFKA_NUM_IO_THREADS` -> `KAFKA_CFG_NUM_IO_THREADS`
-   - `KAFKA_NUM_NETWORK_THREADS` -> `KAFKA_CFG_NUM_NETWORK_THREADS`
-   - `KAFKA_NUM_PARTITIONS` -> `KAFKA_CFG_NUM_PARTITIONS`
-   - `KAFKA_NUM_RECOVERY_THREADS_PER_DATA_DIR` -> `KAFKA_CFG_NUM_RECOVERY_THREADS_PER_DATA_DIR`
-   - `KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR` -> `KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR`
-   - `KAFKA_PORT` -> `KAFKA_CFG_PORT`
-   - `KAFKA_SEGMENT_BYTES` -> `KAFKA_CFG_SEGMENT_BYTES`
-   - `KAFKA_SOCKET_RECEIVE_BUFFER_BYTES` -> `KAFKA_CFG_SOCKET_RECEIVE_BUFFER_BYTES`
-   - `KAFKA_SOCKET_REQUEST_MAX_BYTES` -> `KAFKA_CFG_SOCKET_REQUEST_MAX_BYTES`
-   - `KAFKA_SOCKET_SEND_BUFFER_BYTES` -> `KAFKA_CFG_SOCKET_SEND_BUFFER_BYTES`
-   - `KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM` -> `KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM`
-   - `KAFKA_TRANSACTION_STATE_LOG_MIN_ISR` -> `KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR`
-   - `KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR` -> `KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR`
-   - `KAFKA_ZOOKEEPER_CONNECT_TIMEOUT_MS` -> `KAFKA_CFG_ZOOKEEPER_CONNECT_TIMEOUT_MS`
-   - `KAFKA_ZOOKEEPER_CONNECT` -> `KAFKA_CFG_ZOOKEEPER_CONNECT`
+  * `KAFKA_LOGS_DIRS` -> `KAFKA_CFG_LOG_DIRS`
+  * `KAFKA_PORT_NUMBER` -> `KAFKA_CFG_PORT`
+  * `KAFKA_ZOOKEEPER_CONNECT_TIMEOUT_MS` -> `KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS`
 
-## 1.1.0-r41
+* For consistency reasons with previous environment variables, the following `KAFKA_` to `KAFKA_CFG_` environment variable translations are now supported for mapping into Kafka keys:
 
-- Configuration is not persisted anymore. It should be mounted as a volume or it will be regenerated each time the container is created.
-- Dummy certificates are not used anymore when the SASL_SSL listener is configured. These certificates must be mounted as volumes.
+  * `KAFKA_LOG_DIRS` -> `KAFKA_CFG_LOG_DIRS`
+  * `KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS` -> `KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS`
 
-## 0.10.2.1-r3
+### 1.1.1-debian-9-r205, 2.2.0-debian-9-r40, 1.1.1-ol-7-r286, and 2.2.0-ol-7-r53
 
-- The kafka container has been migrated to a non-root container approach. Previously the container run as `root` user and the kafka daemon was started as `kafka` user. From now own, both the container and the kafka daemon run as user `1001`.
+Configuration changes. Most environment variables now start with `KAFKA_CFG_`, as they are now mapped directly to Kafka keys. Variables changed:
+
+* `KAFKA_ADVERTISED_LISTENERS` -> `KAFKA_CFG_ADVERTISED_LISTENERS`
+* `KAFKA_BROKER_ID` -> `KAFKA_CFG_BROKER_ID`
+* `KAFKA_DEFAULT_REPLICATION_FACTOR` -> `KAFKA_CFG_DEFAULT_REPLICATION_FACTOR`
+* `KAFKA_DELETE_TOPIC_ENABLE` -> `KAFKA_CFG_DELETE_TOPIC_ENABLE`
+* `KAFKA_INTER_BROKER_LISTENER_NAME` -> `KAFKA_CFG_INTER_BROKER_LISTENER_NAME`
+* `KAFKA_LISTENERS` -> `KAFKA_CFG_LISTENERS`
+* `KAFKA_LISTENER_SECURITY_PROTOCOL_MAP` -> `KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP`
+* `KAFKA_LOGS_DIRS` -> `KAFKA_CFG_LOG_DIRS`
+* `KAFKA_LOG_FLUSH_INTERVAL_MESSAGES` -> `KAFKA_CFG_LOG_FLUSH_INTERVAL_MESSAGES`
+* `KAFKA_LOG_FLUSH_INTERVAL_MS` -> `KAFKA_CFG_LOG_FLUSH_INTERVAL_MS`
+* `KAFKA_LOG_MESSAGE_FORMAT_VERSION` -> `KAFKA_CFG_LOG_MESSAGE_FORMAT_VERSION`
+* `KAFKA_LOG_RETENTION_BYTES` -> `KAFKA_CFG_LOG_RETENTION_BYTES`
+* `KAFKA_LOG_RETENTION_CHECK_INTERVALS_MS` -> `KAFKA_CFG_LOG_RETENTION_CHECK_INTERVAL_MS`
+* `KAFKA_LOG_RETENTION_HOURS` -> `KAFKA_CFG_LOG_RETENTION_HOURS`
+* `KAFKA_MAX_MESSAGE_BYTES` -> `KAFKA_CFG_MESSAGE_MAX_BYTES`
+* `KAFKA_NUM_IO_THREADS` -> `KAFKA_CFG_NUM_IO_THREADS`
+* `KAFKA_NUM_NETWORK_THREADS` -> `KAFKA_CFG_NUM_NETWORK_THREADS`
+* `KAFKA_NUM_PARTITIONS` -> `KAFKA_CFG_NUM_PARTITIONS`
+* `KAFKA_NUM_RECOVERY_THREADS_PER_DATA_DIR` -> `KAFKA_CFG_NUM_RECOVERY_THREADS_PER_DATA_DIR`
+* `KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR` -> `KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR`
+* `KAFKA_PORT` -> `KAFKA_CFG_PORT`
+* `KAFKA_SEGMENT_BYTES` -> `KAFKA_CFG_SEGMENT_BYTES`
+* `KAFKA_SOCKET_RECEIVE_BUFFER_BYTES` -> `KAFKA_CFG_SOCKET_RECEIVE_BUFFER_BYTES`
+* `KAFKA_SOCKET_REQUEST_MAX_BYTES` -> `KAFKA_CFG_SOCKET_REQUEST_MAX_BYTES`
+* `KAFKA_SOCKET_SEND_BUFFER_BYTES` -> `KAFKA_CFG_SOCKET_SEND_BUFFER_BYTES`
+* `KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM` -> `KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM`
+* `KAFKA_TRANSACTION_STATE_LOG_MIN_ISR` -> `KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR`
+* `KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR` -> `KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR`
+* `KAFKA_ZOOKEEPER_CONNECT_TIMEOUT_MS` -> `KAFKA_CFG_ZOOKEEPER_CONNECT_TIMEOUT_MS`
+* `KAFKA_ZOOKEEPER_CONNECT` -> `KAFKA_CFG_ZOOKEEPER_CONNECT`
+
+### 1.1.0-r41
+
+* Configuration is not persisted anymore. It should be mounted as a volume or it will be regenerated each time the container is created.
+* Dummy certificates are not used anymore when the SASL_SSL listener is configured. These certificates must be mounted as volumes.
+
+### 0.10.2.1-r3
+
+* The kafka container has been migrated to a non-root container approach. Previously the container run as `root` user and the kafka daemon was started as `kafka` user. From now own, both the container and the kafka daemon run as user `1001`.
   As a consequence, the configuration files are writable by the user running the kafka process.
 
-## 0.10.2.1-r0
+### 0.10.2.1-r0
 
-- New Bitnami release
+* New Bitnami release
 
-
-# Contributing
+## Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/bitnami-docker-kafka/issues), or submit a [pull request](https://github.com/bitnami/bitnami-docker-kafka/pulls) with your contribution.
 
-# Issues
+## Issues
 
 If you encountered a problem running this container, you can file an [issue](https://github.com/bitnami/bitnami-docker-kafka/issues/new). For us to provide better support, be sure to include the following information in your issue:
 
-- Host OS and version
-- Docker version (`docker version`)
-- Output of `docker info`
-- Version of this container (`echo $BITNAMI_IMAGE_VERSION` inside the container)
-- The command you used to run the container, and any relevant output you saw (masking any sensitive information)
+* Host OS and version
+* Docker version (`docker version`)
+* Output of `docker info`
+* Version of this container (`echo $BITNAMI_IMAGE_VERSION` inside the container)
+* The command you used to run the container, and any relevant output you saw (masking any sensitive information)
 
-# License
+## License
 
 Copyright (c) 2015-2020 Bitnami
 


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR refactors how listeners and authentication is configured on Kafka, allowing users to have different listeners for different purposes, and configure different authentication protocols on them.

The supported listeners will be:

* INTERNAL: used for inter-broker communications.
* CLIENT: used for communications with clients that are within the same network as Kafka brokers.
* EXTERNAL: used for communications with clients that are on a different network.

To use a more complex configuration, users will have to mount their own `server.properties` and `kafka_jaas.conf` configuration files.

**Benefits**

We can achieve more complex configurations without assuming so many configuration details.

**Possible drawbacks**

Users will have to adapt their Docker Compose and scripts files to the new format.

**Applicable issues**

None

**Additional information**

A proposal to adapt the Kafka Helm chart according to these changes can be found here: https://github.com/bitnami/charts/pull/2708
