### PR TITLE
update the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ To do so, add the following environment variables to your docker-compose:
 +     - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
 +     - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
 +     - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://localhost:9093
++     - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
 ```
 
 And expose the extra port:


### PR DESCRIPTION

**Description of the change**

README.md "Accessing Kafka with internal and external clients" configuration description.

**Benefits**

make the kafka container start success and fix exception when using previous configuration.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

exception log infomation:

ERROR Exiting Kafka due to fatal exception (kafka.Kafka$)
java.lang.IllegalArgumentException: requirement failed: inter.broker.listener.name must be a listener name defined in advertised.listeners. The valid options based on currently configured listeners are CLIENT,EXTERNAL
