### PR TITLE
support different types of zookeeper connection

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/kafka/run.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/kafka/run.sh
@@ -14,8 +14,13 @@ set -o pipefail
 # Load Kafka environment variables
 eval "$(kafka_env)"
 
-if [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL ]] || [[ "${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-}" =~ SASL ]]; then
+if [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL ]] || [[ "${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-}" =~ SASL ]] || [[ "${KAFKA_ZOOKEEPER_PROTOCOL:-}" =~ SASL ]]; then
     export KAFKA_OPTS="-Djava.security.auth.login.config=${KAFKA_CONF_DIR}/kafka_jaas.conf"
+fi
+
+if [[ "${KAFKA_ZOOKEEPER_PROTOCOL:-}" =~ SSL ]]; then
+    ZOOKEEPER_SSL_CONFIG=$(zookeeper_get_ssl_config)
+    export KAFKA_OPTS="$KAFKA_OPTS $ZOOKEEPER_SSL_CONFIG"
 fi
 
 flags=("$KAFKA_CONF_FILE")

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -112,11 +112,11 @@ export KAFKA_HEAP_OPTS="${KAFKA_HEAP_OPTS:-"-Xmx1024m -Xms1024m"}"
 export KAFKA_ZOOKEEPER_PASSWORD="${KAFKA_ZOOKEEPER_PASSWORD:-}"
 export KAFKA_ZOOKEEPER_USER="${KAFKA_ZOOKEEPER_USER:-}"
 export KAFKA_ZOOKEEPER_PROTOCOL="${KAFKA_ZOOKEEPER_PROTOCOL:-"SASL"}"
-export ZOO_TLS_CLIENT_KEYSTORE_FILE="${ZOO_TLS_CLIENT_KEYSTORE_FILE:-}"
-export ZOO_TLS_CLIENT_KEYSTORE_PASSWORD="${ZOO_TLS_CLIENT_KEYSTORE_PASSWORD:-}"
-export ZOO_TLS_CLIENT_TRUSTSTORE_FILE="${ZOO_TLS_CLIENT_TRUSTSTORE_FILE:-}"
-export ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD="${ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD:-}"
-export ZOO_TLS_CLIENT_VERIFY_HOSTNAME="${ZOO_TLS_CLIENT_VERIFY_HOSTNAME:-true}"
+export KAFKA_ZOOKEEPER_TLS_CLIENT_KEYSTORE_FILE="${KAFKA_ZOOKEEPER_TLS_CLIENT_KEYSTORE_FILE:-}"
+export KAFKA_ZOOKEEPER_TLS_CLIENT_KEYSTORE_PASSWORD="${KAFKA_ZOOKEEPER_TLS_CLIENT_KEYSTORE_PASSWORD:-}"
+export KAFKA_ZOOKEEPER_TLS_CLIENT_TRUSTSTORE_FILE="${KAFKA_ZOOKEEPER_TLS_CLIENT_TRUSTSTORE_FILE:-}"
+export KAFKA_ZOOKEEPER_TLS_CLIENT_TRUSTSTORE_PASSWORD="${KAFKA_ZOOKEEPER_TLS_CLIENT_TRUSTSTORE_PASSWORD:-}"
+export KAFKA_ZOOKEEPER_TLS_CLIENT_VERIFY_HOSTNAME="${KAFKA_ZOOKEEPER_TLS_CLIENT_VERIFY_HOSTNAME:-true}"
 export KAFKA_CFG_ADVERTISED_LISTENERS="${KAFKA_CFG_ADVERTISED_LISTENERS:-"PLAINTEXT://:9092"}"
 export KAFKA_CFG_LISTENERS="${KAFKA_CFG_LISTENERS:-"PLAINTEXT://:9092"}"
 export KAFKA_CFG_ZOOKEEPER_CONNECT="${KAFKA_CFG_ZOOKEEPER_CONNECT:-"localhost:2181"}"
@@ -279,48 +279,59 @@ kafka_generate_jaas_authentication_file() {
     local -r internal_protocol="${1:-}"
     local -r client_protocol="${2:-}"
 
-    info "Generating JAAS authentication file"
-    if [[ "${client_protocol:-}" =~ SASL ]]; then
-        cat >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
+    if [[ ! -f "${KAFKA_CONF_DIR}/kafka_jaas.conf" ]]; then
+        info "Generating JAAS authentication file"
+        if [[ "${client_protocol:-}" =~ SASL ]]; then
+            cat >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
 KafkaClient {
    org.apache.kafka.common.security.plain.PlainLoginModule required
    username="${KAFKA_CLIENT_USER:-}"
    password="${KAFKA_CLIENT_PASSWORD:-}";
    };
 EOF
-    fi
-    if [[ "${client_protocol:-}" =~ SASL ]] && [[ "${internal_protocol:-}" =~ SASL ]]; then
-        cat >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
+        fi
+        if [[ "${client_protocol:-}" =~ SASL ]] && [[ "${internal_protocol:-}" =~ SASL ]]; then
+            cat >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
 KafkaServer {
    org.apache.kafka.common.security.plain.PlainLoginModule required
    username="${KAFKA_INTER_BROKER_USER:-}"
    password="${KAFKA_INTER_BROKER_PASSWORD:-}"
    user_${KAFKA_INTER_BROKER_USER:-}="${KAFKA_INTER_BROKER_PASSWORD:-}"
    user_${KAFKA_CLIENT_USER:-}="${KAFKA_CLIENT_PASSWORD:-}";
-
    org.apache.kafka.common.security.scram.ScramLoginModule required;
    };
 EOF
-    elif [[ "${client_protocol:-}" =~ SASL ]]; then
-        cat >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
+        elif [[ "${client_protocol:-}" =~ SASL ]]; then
+            cat >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
 KafkaServer {
    org.apache.kafka.common.security.plain.PlainLoginModule required
    user_${KAFKA_CLIENT_USER:-}="${KAFKA_CLIENT_PASSWORD:-}";
-
    org.apache.kafka.common.security.scram.ScramLoginModule required;
    };
 EOF
-    elif [[ "${internal_protocol:-}" =~ SASL ]]; then
-        cat >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
+        elif [[ "${internal_protocol:-}" =~ SASL ]]; then
+            cat >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
 KafkaServer {
    org.apache.kafka.common.security.plain.PlainLoginModule required
    username="${KAFKA_INTER_BROKER_USER:-}"
    password="${KAFKA_INTER_BROKER_PASSWORD:-}"
    user_${KAFKA_INTER_BROKER_USER:-}="${KAFKA_INTER_BROKER_PASSWORD:-}";
-
    org.apache.kafka.common.security.scram.ScramLoginModule required;
    };
 EOF
+        fi
+        if [[ "${KAFKA_ZOOKEEPER_PROTOCOL}" =~ SASL ]] && [[ -n "$KAFKA_ZOOKEEPER_USER" ]] && [[ -n "$KAFKA_ZOOKEEPER_PASSWORD" ]]; then
+            cat >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
+Client {
+   org.apache.kafka.common.security.plain.PlainLoginModule required
+   username="${KAFKA_ZOOKEEPER_USER:-}"
+   password="${KAFKA_ZOOKEEPER_PASSWORD:-}";
+   };
+EOF
+        fi
+    else
+        info "Custom JAAS authentication file detected. Skipping generation."
+        warn "The following environment variables will be ignored: KAFKA_CLIENT_USER, KAFKA_CLIENT_PASSWORD, KAFKA_INTER_BROKER_USER, KAFKA_INTER_BROKER_PASSWORD, KAFKA_ZOOKEEPER_USER and KAFKA_ZOOKEEPER_PASSWORD"
     fi
 }
 
@@ -424,29 +435,6 @@ kafka_configure_client_communications() {
 }
 
 ########################
-# Generate JAAS authentication file for Zookeeper connection
-# Globals:
-#   KAFKA_*
-# Arguments:
-#   None
-# Returns:
-#   None
-#########################
-zookeeper_generate_jaas_authentication_file() {
-     if [[ "${KAFKA_ZOOKEEPER_PROTOCOL}" =~ "SASL" ]]; then
-        if [[ -n "$KAFKA_ZOOKEEPER_USER" ]] && [[ -n "$KAFKA_ZOOKEEPER_PASSWORD" ]]; then
-            cat >> "${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
-Client {
-   org.apache.kafka.common.security.plain.PlainLoginModule required
-   username="${KAFKA_ZOOKEEPER_USER:-}"
-   password="${KAFKA_ZOOKEEPER_PASSWORD:-}";
-   };
-EOF
-        fi
-     fi
-}
-
-########################
 # Get Zookeeper SSL settings
 # Globals:
 #   ZOO_TLS_CLIENT_*
@@ -461,11 +449,11 @@ zookeeper_get_ssl_config() {
     # otherwise the connection attempt to Zookeeper will fail.
     echo "-Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty \
           -Dzookeeper.client.secure=true \
-          -Dzookeeper.ssl.keyStore.location=$ZOO_TLS_CLIENT_KEYSTORE_FILE \
-          -Dzookeeper.ssl.keyStore.password=$ZOO_TLS_CLIENT_KEYSTORE_PASSWORD \
-          -Dzookeeper.ssl.trustStore.location=$ZOO_TLS_CLIENT_TRUSTSTORE_FILE \
-          -Dzookeeper.ssl.trustStore.password=$ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD \
-          -Dzookeeper.ssl.hostnameVerification=$ZOO_TLS_CLIENT_VERIFY_HOSTNAME"
+          -Dzookeeper.ssl.keyStore.location=$KAFKA_ZOOKEEPER_TLS_CLIENT_KEYSTORE_FILE \
+          -Dzookeeper.ssl.keyStore.password=$KAFKA_ZOOKEEPER_TLS_CLIENT_KEYSTORE_PASSWORD \
+          -Dzookeeper.ssl.trustStore.location=$KAFKA_ZOOKEEPER_TLS_CLIENT_TRUSTSTORE_FILE \
+          -Dzookeeper.ssl.trustStore.password=$KAFKA_ZOOKEEPER_TLS_CLIENT_TRUSTSTORE_PASSWORD \
+          -Dzookeeper.ssl.hostnameVerification=$KAFKA_ZOOKEEPER_TLS_CLIENT_VERIFY_HOSTNAME"
 }
 
 ########################
@@ -527,15 +515,9 @@ kafka_initialize() {
                 kafka_configure_client_communications "$client_protocol"
             fi
         fi
-        if [[ "${internal_protocol:-}" =~ SASL ]] || [[ "${client_protocol:-}" =~ SASL ]] || [[ -n "$KAFKA_ZOOKEEPER_USER" && -n "$KAFKA_ZOOKEEPER_PASSWORD" ]]; then
+        if [[ "${internal_protocol:-}" =~ SASL ]] || [[ "${client_protocol:-}" =~ SASL ]] || [[ "${KAFKA_ZOOKEEPER_PROTOCOL}" =~ SASL ]]; then
             kafka_server_conf_set sasl.enabled.mechanisms PLAIN,SCRAM-SHA-256,SCRAM-SHA-512
-            if [[ -f "${KAFKA_CONF_DIR}/kafka_jaas.conf" ]]; then
-                info "Custom JAAS authentication file detected. Skipping generation."
-                warn "The following environment variables will be ignored: KAFKA_CLIENT_USER, KAFKA_CLIENT_PASSWORD, KAFKA_INTER_BROKER_USER, KAFKA_INTER_BROKER_PASSWORD, KAFKA_ZOOKEEPER_USER and KAFKA_ZOOKEEPER_PASSWORD"
-            else
-                kafka_generate_jaas_authentication_file "${internal_protocol:-}" "${client_protocol:-}"
-                zookeeper_generate_jaas_authentication_file
-            fi
+            kafka_generate_jaas_authentication_file "${internal_protocol:-}" "${client_protocol:-}"
         fi
         # Remove security.inter.broker.protocol if KAFKA_CFG_INTER_BROKER_LISTENER_NAME is configured
         if [[ -n "${KAFKA_CFG_INTER_BROKER_LISTENER_NAME:-}" ]]; then

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -424,12 +424,11 @@ kafka_configure_client_communications() {
 }
 
 ########################
-# Generate JAAS authentication file
+# Generate JAAS authentication file for Zookeeper connection
 # Globals:
 #   KAFKA_*
 # Arguments:
-#   $1 - Authentication protocol to use for the internal listener
-#   $2 - Authentication protocol to use for the client listener
+#   None
 # Returns:
 #   None
 #########################
@@ -448,13 +447,13 @@ EOF
 }
 
 ########################
-# Configure Zookeeper SSL settings
+# Get Zookeeper SSL settings
 # Globals:
 #   ZOO_TLS_CLIENT_*
 # Arguments:
 #   None
 # Returns:
-#   None
+#   String
 #########################
 zookeeper_get_ssl_config() {
     # Note that ZooKeeper does not support a key password different from the keystore password, 

--- a/README.md
+++ b/README.md
@@ -188,10 +188,16 @@ The configuration can easily be setup with the Bitnami Kafka Docker image using 
 * `KAFKA_INTER_BROKER_PASSWORD`: Kafka inter broker communication password. Default: **bitnami**
 * `KAFKA_CLIENT_USER`: Kafka client user. Default: **user**
 * `KAFKA_CLIENT_PASSWORD`: Kafka client user password. Default: **bitnami**
-* `KAFKA_ZOOKEEPER_USER`: Kafka Zookeeper user. No defaults
-* `KAFKA_ZOOKEEPER_PASSWORD`: Kafka Zookeeper user password. No defaults
 * `KAFKA_CERTIFICATE_PASSWORD`: Password for certificates. No defaults.
 * `KAFKA_HEAP_OPTS`: Kafka's Java Heap size. Default: **-Xmx1024m -Xms1024m**
+* `KAFKA_ZOOKEEPER_PROTOCOL`: Kafka Zookeeper connection configuation. Available options are **SASL**, **SSL**, **SASL_SSL**, **PLAINTEXT**. Defaults: **SASL**
+* `KAFKA_ZOOKEEPER_USER`: Kafka Zookeeper user. No defaults.
+* `KAFKA_ZOOKEEPER_PASSWORD`: Kafka Zookeeper user password. No defaults.
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_KEYSTORE_FILE`: Kafka Zookeeper KeyStore file path: Default: No Defaults. 
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_KEYSTORE_PASSWORD`: Kafka Zookeeper KeyStore file password and key password. No defaults.
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_TRUSTSTORE_FILE`: Kafka Zookeeper TrustStore file path. No defaults.
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_TRUSTSTORE_PASSWORD`: Kafka Zookeeper TrustStore file password. No defaults.
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_VERIFY_HOSTNAME`: Kafka Zookeeper if hostname verification. Defaults: **true**
 
 Additionally, any environment variable beginning with `KAFKA_CFG_` will be mapped to its corresponding Kafka key. For example, use `KAFKA_CFG_BACKGROUND_THREADS` in order to set `background.threads` or `KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE` in order to configure `auto.create.topics.enable`.
 
@@ -363,11 +369,36 @@ When configuring Kafka with `SASL` or `SASL_SSL` for communications with clients
 * `KAFKA_CLIENT_PASSWORD`: Kafka client user password. Default: **bitnami**
 
 #### Kafka ZooKeeper client configuration
+There are different options of configuration to connect a Zookeeper server.
 
-In order to authenticate Kafka against a Zookeeper server with `SASL` or `SASL_SSL` authentication you should provide the environment variables below:
+In order to connect a Zookeeper server without authentication, you should provide the environment variables below:
 
+* `KAFKA_ZOOKEEPER_PROTOCOL`: **PLAINTEXT**
+
+In order to authenticate Kafka against a Zookeeper server with `SASL`, you should provide the environment variables below:
+
+* `KAFKA_ZOOKEEPER_PROTOCOL`: **SASL**
 * `KAFKA_ZOOKEEPER_USER`: Kafka Zookeeper user. No defaults.
 * `KAFKA_ZOOKEEPER_PASSWORD`: Kafka Zookeeper user password. No defaults.
+
+In order to authenticate Kafka against a Zookeeper server with `SSL`, you should provide the environment variables below:
+* `KAFKA_ZOOKEEPER_PROTOCOL`: **SSL**
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_KEYSTORE_FILE`: Kafka Zookeeper KeyStore file path: Default: No Defaults. 
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_KEYSTORE_PASSWORD`: Kafka Zookeeper KeyStore file password and key password. No defaults.
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_TRUSTSTORE_FILE`: Kafka Zookeeper TrustStore file path. No defaults.
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_TRUSTSTORE_PASSWORD`: Kafka Zookeeper TrustStore file password. No defaults.
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_VERIFY_HOSTNAME`: Kafka Zookeeper if hostname verification. Defaults: **true**
+
+In order to authenticate Kafka against a Zookeeper server with `SASL_SSL`, you should provide the environment variables below:
+* `KAFKA_ZOOKEEPER_PROTOCOL`: **SASL_SSL**
+* `KAFKA_ZOOKEEPER_USER`: Kafka Zookeeper user. No defaults.
+* `KAFKA_ZOOKEEPER_PASSWORD`: Kafka Zookeeper user password. No defaults.
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_KEYSTORE_FILE`: Kafka Zookeeper KeyStore file path: Default: No Defaults. 
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_KEYSTORE_PASSWORD`: Kafka Zookeeper KeyStore file password and key password. No defaults.
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_TRUSTSTORE_FILE`: Kafka Zookeeper TrustStore file path. No defaults.
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_TRUSTSTORE_PASSWORD`: Kafka Zookeeper TrustStore file password. No defaults.
+* `KAFKA_ZOOKEEPER_TLS_CLIENT_VERIFY_HOSTNAME`: Kafka Zookeeper if hostname verification. Defaults: **true**
+
 
 ### Setting up a Kafka Cluster
 


### PR DESCRIPTION
@andresbono 

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR refactor the zookeeper connection configuration which is separated from the Kafka configuration, allow users to config zookeeper connection in 4 types:

1. KAFKA_ZOOKEEPER_PROTOCOL="SASL"
    Use JAAS authentication configuration for zookeeper connection. Users must provide KAFKA_ZOOKEEPER_USER and KAFKA_ZOOKEEPER_PASSWORD.

2. KAFKA_ZOOKEEPER_PROTOCOL="SSL"
    Use TLS configuration for zookeeper connection.

3. KAFKA_ZOOKEEPER_PROTOCOL="SASL_SSL"
   Use JAAS and TLS configuration for zookeeper connection.

4. otherwise, kafka will connect to zookeeper in a plaintext way.

**Benefits**

Users can config the zookeeper connection in different ways.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

see #114 

**Additional information**

The current Kafka chart won't break.
Need to adapt the Kafka Chart according to these changes if they want to support TLS zookeeper connection.

Tested it with TLS-enabled zookeeper service and it worked.
