### PR TITLE
Corrects default mounted directory location

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ Topic:mytopic   PartitionCount:3        ReplicationFactor:3     Configs:
 The image looks for configuration files (server.properties, log4j.properties, etc.) in the `/bitnami/kafka/config/` directory, this directory can be changed by setting the KAFKA_MOUNTED_CONF_DIR environment variable.
 
 ```console
-$ docker run --name kafka -v /path/to/server.properties:/bitnami/kafka/conf/server.properties bitnami/kafka:latest
+$ docker run --name kafka -v /path/to/server.properties:/bitnami/kafka/config/server.properties bitnami/kafka:latest
 ```
 
 After that, your changes will be taken into account in the server's behaviour.
@@ -569,7 +569,7 @@ services:
     ...
     volumes:
       - 'kafka_data:/bitnami'
-+     - /path/to/server.properties:/bitnami/kafka/conf/server.properties
++     - /path/to/server.properties:/bitnami/kafka/config/server.properties
 ```
 
 #### Step 2: Edit the configuration


### PR DESCRIPTION
Scope: documentation update

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

When the ability to copy configuration files was added with https://github.com/bitnami/bitnami-docker-kafka/pull/91 the README wasn't fully updated to reflect the new default mounted config location.

**Benefits**

The README will not conflict with itself.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
