### PR TITLE
Make client authentication configurable

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -124,7 +124,7 @@ export KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE="${KAFKA_CFG_AUTO_CREATE_TOPICS_ENABL
 export KAFKA_CFG_SASL_ENABLED_MECHANISMS="${KAFKA_CFG_SASL_ENABLED_MECHANISMS:-PLAIN,SCRAM-SHA-256,SCRAM-SHA-512}"
 export KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL="${KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL:-}"
 export KAFKA_CFG_TLS_TYPE="${KAFKA_CFG_TLS_TYPE:-JKS}"
-export KAFKA_CFG_SSL_CLIENT_AUTH="${KAFKA_CFG_SSL_CLIENT_AUTH:-required}"
+export KAFKA_CFG_TLS_CLIENT_AUTH="${KAFKA_CFG_TLS_CLIENT_AUTH:-required}"
 EOF
     # Make compatible KAFKA_CLIENT_USERS/PASSWORDS with the old KAFKA_CLIENT_USER/PASSWORD
     [[ -n "${KAFKA_CLIENT_USER:-}" ]] && KAFKA_CLIENT_USERS="${KAFKA_CLIENT_USER:-},${KAFKA_CLIENT_USERS:-}"
@@ -297,7 +297,7 @@ kafka_validate() {
     elif ! is_boolean_yes "$ALLOW_PLAINTEXT_LISTENER"; then
          print_validation_error "The KAFKA_ZOOKEEPER_PROTOCOL environment variable does not configure a secure protocol. Set the environment variable ALLOW_PLAINTEXT_LISTENER=yes to allow the container to be started with a plaintext listener. This is only recommended for development."
     fi
-    check_multi_value "KAFKA_CFG_SSL_CLIENT_AUTH" "none requested required"
+    check_multi_value "KAFKA_CFG_TLS_CLIENT_AUTH" "none requested required"
     check_multi_value "KAFKA_CFG_TLS_TYPE" "JKS PEM"
     [[ "$error_code" -eq 0 ]] || return "$error_code"
 }
@@ -523,7 +523,7 @@ kafka_configure_internal_communications() {
             kafka_configure_ssl
             # We need to enable 2 way authentication on SASL_SSL so brokers authenticate each other.
             # It won't affect client communications unless the SSL protocol is for them.
-            kafka_server_conf_set ssl.client.auth "$KAFKA_CFG_SSL_CLIENT_AUTH"
+            kafka_server_conf_set ssl.client.auth "$KAFKA_CFG_TLS_CLIENT_AUTH"
         fi
     else
         error "Authentication protocol ${protocol} is not supported!"
@@ -560,7 +560,7 @@ kafka_configure_client_communications() {
             kafka_configure_ssl
         fi
         if [[ "$protocol" = "SSL" ]]; then
-            kafka_server_conf_set ssl.client.auth "$KAFKA_CFG_SSL_CLIENT_AUTH"
+            kafka_server_conf_set ssl.client.auth "$KAFKA_CFG_TLS_CLIENT_AUTH"
         fi
     else
         error "Authentication protocol ${protocol} is not supported!"

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -240,6 +240,11 @@ kafka_validate() {
             print_validation_error "An invalid port was specified in the environment variable KAFKA_CFG_LISTENERS: $err"
         fi
     }
+    check_multi_value() {
+        if [[ " ${2} " != *" ${!1} "* ]]; then
+            print_validation_error "The allowed values for ${1} are: ${2}"
+        fi
+    }
 
     if [[ ${KAFKA_CFG_LISTENERS:-} =~ INTERNAL://:([0-9]*) ]]; then
         internal_port="${BASH_REMATCH[1]}"

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ The configuration can easily be setup with the Bitnami Kafka Docker image using 
 * `KAFKA_ZOOKEEPER_TLS_VERIFY_HOSTNAME`: Verify Zookeeper hostname on TLS certificates. Defaults: **true**.
 * `KAFKA_CFG_SASL_ENABLED_MECHANISMS`: Allowed mechanism when using SASL either for clients, inter broker, or zookeeper comunications. Allowed values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512` or a comma separated combination of those values. Default: **PLAIN,SCRAM-SHA-256,SCRAM-SHA-512**
 * `KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL`: SASL mechanism to use for inter broker communications. No defaults.
+* `KAFKA_CFG_SSL_CLIENT_AUTH`: Configures kafka brokers to request client authentication. Allowed values: `required`, `requested`, `none`. Defaults: **required**
 * `KAFKA_CLIENT_USERS`: Additional users to `KAFKA_CLIENT_USER` that will be created into Zookeeper when using SASL_SCRAM for client communications. Separated by commas. Default: **user**
 * `KAFKA_CLIENT_PASSWORDS`: Passwords for the users specified at`KAFKA_CLIENT_USERS`. Separated by commas. Default: **bitnami**
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The configuration can easily be setup with the Bitnami Kafka Docker image using 
 * `KAFKA_ZOOKEEPER_TLS_VERIFY_HOSTNAME`: Verify Zookeeper hostname on TLS certificates. Defaults: **true**.
 * `KAFKA_CFG_SASL_ENABLED_MECHANISMS`: Allowed mechanism when using SASL either for clients, inter broker, or zookeeper comunications. Allowed values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512` or a comma separated combination of those values. Default: **PLAIN,SCRAM-SHA-256,SCRAM-SHA-512**
 * `KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL`: SASL mechanism to use for inter broker communications. No defaults.
-* `KAFKA_CFG_SSL_CLIENT_AUTH`: Configures kafka brokers to request client authentication. Allowed values: `required`, `requested`, `none`. Defaults: **required**
+* `KAFKA_CFG_TLS_CLIENT_AUTH`: Configures kafka brokers to request client authentication. Allowed values: `required`, `requested`, `none`. Defaults: **required**
 * `KAFKA_CFG_TLS_TYPE`: Choose the TLS certificate format to use. Allowed values: `JKS`, `PEM`. Defaults: **JKS**
 * `KAFKA_CLIENT_USERS`: Additional users to `KAFKA_CLIENT_USER` that will be created into Zookeeper when using SASL_SCRAM for client communications. Separated by commas. Default: **user**
 * `KAFKA_CLIENT_PASSWORDS`: Passwords for the users specified at`KAFKA_CLIENT_USERS`. Separated by commas. Default: **bitnami**


### PR DESCRIPTION
**Description of the change**

This change adds a new environment variable (`KAFKA_CFG_SSL_CLIENT_AUTH`) which allows users to choose whether to enable client authentication or not, while keeping encryption enabled. This new environment variable maps 1 to 1 with Kafka's `ssl.client.auth`. As such, the same values can be used:

* `none`: Disables client authentication completely
* `requested`: Enables client authentication without making it mandatory
* `required`: Enables client authentication for all client connections (default value to keep backwards compatibility)

If an invalid value is used an error message is logged indicating which values should be used.

To maintain backwards compatibility, `required` is the default value (which was previously hardcoded).

**Benefits**

<!-- What benefits will be realized by the code change? -->

Adds flexibility when deciding how to secure the Kafka cluster. While mTLS provides both encryption and authentication, in some instances it can be a hassle managing certificates for clients. With this option brokers can be deployed with TLS enabled, which provides encryption without the burden of generating client certificates.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

[Link to Kafka ssl.client.auth docs](https://kafka.apache.org/documentation/#connectconfigs_ssl.client.auth)
