### PR TITLE
Add support for PEM certificate files

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -99,6 +99,7 @@ export KAFKA_LOG_DIR="$KAFKA_BASE_DIR"/logs
 export KAFKA_CONF_DIR="${KAFKA_CONF_DIR:-"$KAFKA_BASE_DIR"/config}"
 export KAFKA_CONF_FILE="$KAFKA_CONF_DIR"/server.properties
 export KAFKA_MOUNTED_CONF_DIR="${KAFKA_MOUNTED_CONF_DIR:-${KAFKA_VOLUME_DIR}/config}"
+export KAFKA_CERTS_DIR="$KAFKA_CONF_DIR"/certs
 export KAFKA_DATA_DIR="$KAFKA_VOLUME_DIR"/data
 export KAFKA_INITSCRIPTS_DIR=/docker-entrypoint-initdb.d
 export KAFKA_DAEMON_USER="kafka"
@@ -122,6 +123,7 @@ export KAFKA_CFG_ZOOKEEPER_CONNECT="${KAFKA_CFG_ZOOKEEPER_CONNECT:-"localhost:21
 export KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE="${KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE:-"true"}"
 export KAFKA_CFG_SASL_ENABLED_MECHANISMS="${KAFKA_CFG_SASL_ENABLED_MECHANISMS:-PLAIN,SCRAM-SHA-256,SCRAM-SHA-512}"
 export KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL="${KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL:-}"
+export KAFKA_CFG_TLS_TYPE="${KAFKA_CFG_TLS_TYPE:-JKS}"
 EOF
     # Make compatible KAFKA_CLIENT_USERS/PASSWORDS with the old KAFKA_CLIENT_USER/PASSWORD
     [[ -n "${KAFKA_CLIENT_USER:-}" ]] && KAFKA_CLIENT_USERS="${KAFKA_CLIENT_USER:-},${KAFKA_CLIENT_USERS:-}"
@@ -269,9 +271,11 @@ kafka_validate() {
         warn "You set the environment variable ALLOW_PLAINTEXT_LISTENER=$ALLOW_PLAINTEXT_LISTENER. For safety reasons, do not use this flag in a production environment."
     fi
     if [[ "${KAFKA_CFG_LISTENERS:-}" =~ SSL ]] || [[ "${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-}" =~ SSL ]]; then
-        if ([[ ! -f "$KAFKA_CONF_DIR"/certs/kafka.keystore.jks ]] || [[ ! -f "$KAFKA_CONF_DIR"/certs/kafka.truststore.jks ]]) \
-            && ([[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/kafka.keystore.jks ]] || [[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/kafka.truststore.jks ]]); then
-            print_validation_error "In order to configure the TLS encryption for Kafka you must mount your kafka.keystore.jks and kafka.truststore.jks certificates to the ${KAFKA_MOUNTED_CONF_DIR}/certs directory."
+        if ([[ ! -f "$KAFKA_CERTS_DIR"/kafka.keystore.jks ]] || [[ ! -f "$KAFKA_CERTS_DIR"/kafka.truststore.jks ]]) \
+            && ([[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/kafka.keystore.jks ]] || [[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/kafka.truststore.jks ]]) \
+            && ([[ ! -f "$KAFKA_CERTS_DIR"kafka.keystore.pem ]] || [[ ! -f "$KAFKA_CERTS_DIR"/certs/kafka.truststore.pem ]]) \
+            && ([[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/kafka.keystore.pem ]] || [[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/kafka.truststore.pem ]]); then
+            print_validation_error "In order to configure the TLS encryption for Kafka you must mount your kafka.keystore.jks (or kafka.keystore.pem) and kafka.truststore.jks (or kafka.trustsore.pem) certificates to the ${KAFKA_MOUNTED_CONF_DIR}/certs directory."
         fi
     elif [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL ]] || [[ "${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-}" =~ SASL ]]; then
         if [[ -z "$KAFKA_CLIENT_PASSWORD" && -z "$KAFKA_CLIENT_PASSWORDS" ]] && [[ -z "$KAFKA_INTER_BROKER_PASSWORD" ]]; then
@@ -281,7 +285,7 @@ kafka_validate() {
         print_validation_error "The KAFKA_CFG_LISTENERS environment variable does not configure a secure listener. Set the environment variable ALLOW_PLAINTEXT_LISTENER=yes to allow the container to be started with a plaintext listener. This is only recommended for development."
     fi
     if [[ "${KAFKA_ZOOKEEPER_PROTOCOL}" =~ SSL ]]; then
-        if ([[ ! -f "$KAFKA_CONF_DIR"/certs/zookeeper.keystore.jks ]] || [[ ! -f "$KAFKA_CONF_DIR"/certs/zookeeper.truststore.jks ]]) \
+        if ([[ ! -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.jks ]] || [[ ! -f "$KAFKA_CERTS_DIR"/zookeeper.truststore.jks ]]) \
             && ([[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/zookeeper.keystore.jks ]] || [[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/zookeeper.truststore.jks ]]); then
             print_validation_error "In order to configure the TLS encryption for Zookeeper you must mount your zookeeper.keystore.jks and zookeeper.truststore.jks certificates to the ${KAFKA_MOUNTED_CONF_DIR}/certs directory."
         fi
@@ -292,6 +296,7 @@ kafka_validate() {
     elif ! is_boolean_yes "$ALLOW_PLAINTEXT_LISTENER"; then
          print_validation_error "The KAFKA_ZOOKEEPER_PROTOCOL environment variable does not configure a secure protocol. Set the environment variable ALLOW_PLAINTEXT_LISTENER=yes to allow the container to be started with a plaintext listener. This is only recommended for development."
     fi
+    check_multi_value "KAFKA_CFG_TLS_TYPE" "JKS PEM"
     [[ "$error_code" -eq 0 ]] || return "$error_code"
 }
 
@@ -460,18 +465,27 @@ kafka_create_sasl_scram_zookeeper_users() {
 #   None
 #########################
 kafka_configure_ssl() {
+    local -r ext="${KAFKA_CFG_TLS_TYPE,,}"
+
     # Set Kafka configuration
-    kafka_server_conf_set ssl.keystore.location "$KAFKA_CONF_DIR"/certs/kafka.keystore.jks
-    kafka_server_conf_set ssl.keystore.password "$KAFKA_CERTIFICATE_PASSWORD"
+    kafka_server_conf_set ssl.keystore.type "$KAFKA_CFG_TLS_TYPE"
+    kafka_server_conf_set ssl.keystore.location "$KAFKA_CERTS_DIR"/kafka.keystore."$ext"
     kafka_server_conf_set ssl.key.password "$KAFKA_CERTIFICATE_PASSWORD"
-    kafka_server_conf_set ssl.truststore.location "$KAFKA_CONF_DIR"/certs/kafka.truststore.jks
-    kafka_server_conf_set ssl.truststore.password "$KAFKA_CERTIFICATE_PASSWORD"
+    kafka_server_conf_set ssl.truststore.type "$KAFKA_CFG_TLS_TYPE"
+    kafka_server_conf_set ssl.truststore.location "$KAFKA_CERTS_DIR"/kafka.truststore."$ext"
     # Set producer/consumer configuration
-    kafka_producer_consumer_conf_set ssl.keystore.location "$KAFKA_CONF_DIR"/certs/kafka.keystore.jks
-    kafka_producer_consumer_conf_set ssl.keystore.password "$KAFKA_CERTIFICATE_PASSWORD"
-    kafka_producer_consumer_conf_set ssl.truststore.location "$KAFKA_CONF_DIR"/certs/kafka.truststore.jks
-    kafka_producer_consumer_conf_set ssl.truststore.password "$KAFKA_CERTIFICATE_PASSWORD"
+    kafka_producer_consumer_conf_set ssl.keystore.type "$KAFKA_CFG_TLS_TYPE"
+    kafka_producer_consumer_conf_set ssl.keystore.location "$KAFKA_CERTS_DIR"/kafka.keystore."$ext"
     kafka_producer_consumer_conf_set ssl.key.password "$KAFKA_CERTIFICATE_PASSWORD"
+    kafka_producer_consumer_conf_set ssl.truststore.type "$KAFKA_CFG_TLS_TYPE"
+    kafka_producer_consumer_conf_set ssl.truststore.location "$KAFKA_CERTS_DIR"/kafka.truststore."$ext"
+    # keystore and truststore passwords are only compatible with JKS files
+    if [[ "$KAFKA_CFG_TLS_TYPE" == "JKS" ]]; then
+        kafka_server_conf_set ssl.keystore.password "$KAFKA_CERTIFICATE_PASSWORD"
+        kafka_server_conf_set ssl.truststore.password "$KAFKA_CERTIFICATE_PASSWORD"
+        kafka_producer_consumer_conf_set ssl.keystore.password "$KAFKA_CERTIFICATE_PASSWORD"
+        kafka_producer_consumer_conf_set ssl.truststore.password "$KAFKA_CERTIFICATE_PASSWORD"
+    fi
 }
 
 ########################
@@ -567,9 +581,9 @@ zookeeper_get_tls_config() {
     # otherwise the connection attempt to Zookeeper will fail.
     echo "-Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty \
           -Dzookeeper.client.secure=true \
-          -Dzookeeper.ssl.keyStore.location=${KAFKA_CONF_DIR}/certs/zookeeper.keystore.jks \
+          -Dzookeeper.ssl.keyStore.location=${KAFKA_CERTS_DIR}/zookeeper.keystore.jks \
           -Dzookeeper.ssl.keyStore.password=$KAFKA_ZOOKEEPER_TLS_KEYSTORE_PASSWORD \
-          -Dzookeeper.ssl.trustStore.location=${KAFKA_CONF_DIR}/certs/zookeeper.truststore.jks \
+          -Dzookeeper.ssl.trustStore.location=${KAFKA_CERTS_DIR}/zookeeper.truststore.jks \
           -Dzookeeper.ssl.trustStore.password=$KAFKA_ZOOKEEPER_TLS_TRUSTSTORE_PASSWORD \
           -Dzookeeper.ssl.hostnameVerification=$KAFKA_ZOOKEEPER_TLS_VERIFY_HOSTNAME"
 }

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -240,6 +240,11 @@ kafka_validate() {
             print_validation_error "An invalid port was specified in the environment variable KAFKA_CFG_LISTENERS: $err"
         fi
     }
+    check_multi_value() {
+        if [[ " ${2} " != *" ${!1} "* ]]; then
+            print_validation_error "The allowed values for ${1} are: ${2}"
+        fi
+    }
 
     if [[ ${KAFKA_CFG_LISTENERS:-} =~ INTERNAL://:([0-9]*) ]]; then
         internal_port="${BASH_REMATCH[1]}"

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ The configuration can easily be setup with the Bitnami Kafka Docker image using 
 * `KAFKA_ZOOKEEPER_TLS_VERIFY_HOSTNAME`: Verify Zookeeper hostname on TLS certificates. Defaults: **true**.
 * `KAFKA_CFG_SASL_ENABLED_MECHANISMS`: Allowed mechanism when using SASL either for clients, inter broker, or zookeeper comunications. Allowed values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512` or a comma separated combination of those values. Default: **PLAIN,SCRAM-SHA-256,SCRAM-SHA-512**
 * `KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL`: SASL mechanism to use for inter broker communications. No defaults.
+* `KAFKA_CFG_TLS_TYPE`: Choose the TLS certificate format to use. Allowed values: `JKS`, `PEM`. Defaults: **JKS**
 * `KAFKA_CLIENT_USERS`: Additional users to `KAFKA_CLIENT_USER` that will be created into Zookeeper when using SASL_SCRAM for client communications. Separated by commas. Default: **user**
 * `KAFKA_CLIENT_PASSWORDS`: Passwords for the users specified at`KAFKA_CLIENT_USERS`. Separated by commas. Default: **bitnami**
 
@@ -323,7 +324,7 @@ KAFKA_CLIENT_USER=user
 KAFKA_CLIENT_PASSWORD=password
 ```
 
-You **must** also use your own certificates for SSL. You can drop your Java Key Stores files into `/opt/bitnami/kafka/config/certs`. If the JKS is password protected (recommended), you will need to provide it to get access to the keystores:
+You **must** also use your own certificates for SSL. You can drop your Java Key Stores or PEM files into `/opt/bitnami/kafka/config/certs`. If the JKS or PEM is password protected (recommended), you will need to provide it to get access to the keystores:
 
 `KAFKA_CERTIFICATE_PASSWORD=myCertificatePassword`
 
@@ -366,9 +367,12 @@ services:
       - KAFKA_CLIENT_USER=user
       - KAFKA_CLIENT_PASSWORD=password
       - KAFKA_CERTIFICATE_PASSWORD=certificatePassword123
+      - KAFKA_CFG_TLS_TYPE=JKS # or PEM
     volumes:
+      # Both .jks and .pem files are supported
       - './kafka.keystore.jks:/opt/bitnami/kafka/config/certs/kafka.keystore.jks:ro'
       - './kafka.truststore.jks:/opt/bitnami/kafka/config/certs/kafka.truststore.jks:ro'
+
 ```
 
 In order to get the required credentials to consume and produce messages you need to provide the credentials in the client. If your Kafka client allows it, use the credentials you've provided.


### PR DESCRIPTION
**Description of the change**

Adds support for truststore and keystore certificates in PEM format (in addition to JKS).

No new configuration parameters have been added. To use PEM certs they must be placed and called in a specific way (in a similar fashion to how JKS must be configured in the container):

* `kafka.pem`: public certificate (equivalent to part of the JKS keystore)
* `kafka.key`: private key (equivalent to part of the JKS keystore)
* `ca-cert`: public CA certificate (equivalent to the JKS truststore)

The private key can be encrypted. Set the password with the KAFKA_CERTIFICATE_PASSWORD environment variable.

The keys and certificates will be stored as a multi-line string in the properties files. e.g.:

```
ssl.truststore.certificates=-----BEGIN CERTIFICATE----- \
MIIDrzCCApegAwIBAgIUYFLNWpsO1I5AbYxSfG05qXZaBK0wDQYJKoZIhvcNAQEL \
BQAwZzELMAkGA1UEBhMCTk4xCzAJBgNVBAgMAk5OMQswCQYDVQQHDAJOTjELMAkG \
A1UECgwCTk4xCzAJBgNVBAsMAk5OMQwwCgYDVQQDDANzbWQxFjAUBgkqhkiG9w0B \
CQEWB2hmc0BzbWQwHhcNMjEwMTI1MTE0OTA5WhcNNDgwNjEyMTE0OTA5WjBnMQsw \
CQYDVQQGEwJOTjELMAkGA1UECAwCTk4xCzAJBgNVBAcMAk5OMQswCQYDVQQKDAJO \
TjELMAkGA1UECwwCTk4xDDAKBgNVBAMMA3NtZDEWMBQGCSqGSIb3DQEJARYHaGZz \
QHNtZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJbwktqe5JiwvtRB \
ka0E3H295GJDHVmLKpXqzwg+cAqjrE0SYE+X4rs9jgztXYsYJOtAqBB7nsNOV1Ly \
O8jSzT/0UnUPx7KpWNRzmTvSpRaCH9HL7NthSuENXLcPYFd2BCSL7NBCszmGVRhw \
TJCOHjbIez9kK3qXHOcnsuXsCaSuiipr/JNkvkgOyamm7qBGOHCoRvKA9WFoKqDh \
12z497nwHtPyZIYeQjBOi++pmusMQZt7y5N5zHDIeg1CD7Jw0eCcVzkSep5LL/7t \
Fuvr9+pIUpo/pdINMrpXV4c+ZYdd6RHvvq94jJQS3vl/G088peCKtER288otxdZZ \
eFOEAX0CAwEAAaNTMFEwHQYDVR0OBBYEFLi4eQDLbB5+hKAo6H3aIp9NAVjhMB8G \
A1UdIwQYMBaAFLi4eQDLbB5+hKAo6H3aIp9NAVjhMA8GA1UdEwEB/wQFMAMBAf8w \
DQYJKoZIhvcNAQELBQADggEBAG0XF9HFYOIkc/JwIPe3iWl2fP3qN3XP0wTZBq5i \
GlsopYLbgqx0ZVp08o5aljIOsDduPYrJc5aYbxs7l1mxXSxS8qaxe2eg8s/DMiRE \
Bxqunqet+wnWjLEYeCjS832OShF0YUi7nHH2VN4PQjxzxYDxddGYTtcSxHiSAYLA \
X9TW8sWR2WL9bN2ThO7qnN/sq08W1W0FaGy4Vtha4/bm3JKRtfoifrWffxX45MZE \
OGhIutv0PNniufgU5Iej6p+ixNsVDeQPoF9eLiFQ0Mh+AvwtLpg+NVkRiGs8WpYT \
PzAz4bpRnammIU0QEgvyRWuNoA8fE+YDuRBzX0ETyjIXX+E= \
-----END CERTIFICATE-----
```

**Benefits**

In some cases, PEM certificates can be simpler to generate and provision than JKS ones. Generating them doesn't depend on Java's keytool.

**Possible drawbacks**

When configuring `SSL` encryption, `libkafka.sh` will call the `kafka_configure_ssl` more than once. Unfortunately, the `replace_in_file ` function is not compatible with multi-line values, and will be used from the second call to `kafka_configure_ssl` onwards. To solve this I added a variable (`SSL_CONFIGURED`) which keeps track if the SSL settings have already been set in the properties files.

I think a better solution would be to prevent `kafka_configure_ssl` to be called more than once in the first place.

Another solution could be replacing the sed subtitution with a more complex regex (using perl for example) which can accommodate multi-lint strings if needed (e.g. `VALUE="${value}" perl -0777 -i -pe 's/^[#\\s]*'"${key}"'\s*=.*?(?<! \\)$/'"${key}"'=$ENV{VALUE}/gsm' "$file"`).

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

[KIP-651](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=158870088)

[Kafka docs](https://kafka.apache.org/documentation/#security_ssl_signing)
