### PR TITLE
Increase flexibility of zookeeper TLS files

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -117,6 +117,7 @@ export KAFKA_ZOOKEEPER_USER="${KAFKA_ZOOKEEPER_USER:-}"
 export KAFKA_ZOOKEEPER_TLS_KEYSTORE_PASSWORD="${KAFKA_ZOOKEEPER_TLS_KEYSTORE_PASSWORD:-}"
 export KAFKA_ZOOKEEPER_TLS_TRUSTSTORE_PASSWORD="${KAFKA_ZOOKEEPER_TLS_TRUSTSTORE_PASSWORD:-}"
 export KAFKA_ZOOKEEPER_TLS_VERIFY_HOSTNAME="${KAFKA_ZOOKEEPER_TLS_VERIFY_HOSTNAME:-"true"}"
+export KAFKA_ZOOKEEPER_TLS_TYPE="${KAFKA_ZOOKEEPER_TLS_TYPE:-JKS}"
 export KAFKA_CFG_ADVERTISED_LISTENERS="${KAFKA_CFG_ADVERTISED_LISTENERS:-"PLAINTEXT://:9092"}"
 export KAFKA_CFG_LISTENERS="${KAFKA_CFG_LISTENERS:-"PLAINTEXT://:9092"}"
 export KAFKA_CFG_ZOOKEEPER_CONNECT="${KAFKA_CFG_ZOOKEEPER_CONNECT:-"localhost:2181"}"
@@ -287,9 +288,13 @@ kafka_validate() {
         print_validation_error "The KAFKA_CFG_LISTENERS environment variable does not configure a secure listener. Set the environment variable ALLOW_PLAINTEXT_LISTENER=yes to allow the container to be started with a plaintext listener. This is only recommended for development."
     fi
     if [[ "${KAFKA_ZOOKEEPER_PROTOCOL}" =~ SSL ]]; then
-        if ([[ ! -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.jks ]] || [[ ! -f "$KAFKA_CERTS_DIR"/zookeeper.truststore.jks ]]) \
-            && ([[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/zookeeper.keystore.jks ]] || [[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/zookeeper.truststore.jks ]]); then
-            print_validation_error "In order to configure the TLS encryption for Zookeeper you must mount your zookeeper.keystore.jks and zookeeper.truststore.jks certificates to the ${KAFKA_MOUNTED_CONF_DIR}/certs directory."
+        if [[ ! -f "$KAFKA_CERTS_DIR"/zookeeper.truststore.jks ]] && [[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/zookeeper.truststore.jks ]] \
+            && [[ ! -f "$KAFKA_CERTS_DIR"/zookeeper.truststore.pem ]] && [[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/zookeeper.truststore.pem ]]; then
+            print_validation_error "In order to configure the TLS encryption for Zookeeper you must mount your zookeeper.truststore.jks (or zookeeper.truststore.pem) certificates to the ${KAFKA_MOUNTED_CONF_DIR}/certs directory."
+        fi
+        if [[ ! -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.jks ]] && [[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/zookeeper.keystore.jks ]] \
+            && [[ ! -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem ]] && [[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/certs/zookeeper.keystore.pem ]]; then
+            warn "In order to configure the mTLS for Zookeeper you must mount your zookeeper.keystore.jks (or zookeeper.keystore.pem) certificates to the ${KAFKA_MOUNTED_CONF_DIR}/certs directory."
         fi
     elif [[ "${KAFKA_ZOOKEEPER_PROTOCOL}" =~ SASL ]]; then
         if [[ -z "$KAFKA_ZOOKEEPER_USER" ]] || [[ -z "$KAFKA_ZOOKEEPER_PASSWORD" ]]; then
@@ -581,11 +586,18 @@ zookeeper_get_tls_config() {
     # Note that ZooKeeper does not support a key password different from the keystore password,
     # so be sure to set the key password in the keystore to be identical to the keystore password;
     # otherwise the connection attempt to Zookeeper will fail.
+
+    local -r ext="${KAFKA_ZOOKEEPER_TLS_TYPE,,}"
+    local keystore_location=""
+    if [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore."$ext" ]]; then
+        keystore_location="${KAFKA_CERTS_DIR}/zookeeper.keystore.${ext}"
+    fi
+
     echo "-Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty \
           -Dzookeeper.client.secure=true \
-          -Dzookeeper.ssl.keyStore.location=${KAFKA_CERTS_DIR}/zookeeper.keystore.jks \
+          -Dzookeeper.ssl.keyStore.location=${keystore_location} \
           -Dzookeeper.ssl.keyStore.password=$KAFKA_ZOOKEEPER_TLS_KEYSTORE_PASSWORD \
-          -Dzookeeper.ssl.trustStore.location=${KAFKA_CERTS_DIR}/zookeeper.truststore.jks \
+          -Dzookeeper.ssl.trustStore.location=${KAFKA_CERTS_DIR}/zookeeper.truststore.${ext} \
           -Dzookeeper.ssl.trustStore.password=$KAFKA_ZOOKEEPER_TLS_TRUSTSTORE_PASSWORD \
           -Dzookeeper.ssl.hostnameVerification=$KAFKA_ZOOKEEPER_TLS_VERIFY_HOSTNAME"
 }

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The configuration can easily be setup with the Bitnami Kafka Docker image using 
 * `KAFKA_ZOOKEEPER_TLS_KEYSTORE_PASSWORD`: Kafka Zookeeper keystore file password and key password. No defaults.
 * `KAFKA_ZOOKEEPER_TLS_TRUSTSTORE_PASSWORD`: Kafka Zookeeper truststore file password. No defaults.
 * `KAFKA_ZOOKEEPER_TLS_VERIFY_HOSTNAME`: Verify Zookeeper hostname on TLS certificates. Defaults: **true**.
+* `KAFKA_ZOOKEEPER_TLS_TYPE`: Choose the TLS certificate format to use. Allowed values: `JKS`, `PEM`. Defaults: **JKS**.
 * `KAFKA_CFG_SASL_ENABLED_MECHANISMS`: Allowed mechanism when using SASL either for clients, inter broker, or zookeeper comunications. Allowed values: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512` or a comma separated combination of those values. Default: **PLAIN,SCRAM-SHA-256,SCRAM-SHA-512**
 * `KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL`: SASL mechanism to use for inter broker communications. No defaults.
 * `KAFKA_CFG_TLS_CLIENT_AUTH`: Configures kafka brokers to request client authentication. Allowed values: `required`, `requested`, `none`. Defaults: **required**.
@@ -430,6 +431,7 @@ In order to authenticate Kafka against a Zookeeper server with `SSL`, you should
 * `KAFKA_ZOOKEEPER_TLS_KEYSTORE_PASSWORD`: Kafka Zookeeper keystore file password and key password. No defaults.
 * `KAFKA_ZOOKEEPER_TLS_TRUSTSTORE_PASSWORD`: Kafka Zookeeper truststore file password. No defaults.
 * `KAFKA_ZOOKEEPER_TLS_VERIFY_HOSTNAME`: Verify Zookeeper hostname on TLS certificates. Defaults: **true**.
+* `KAFKA_ZOOKEEPER_TLS_TYPE`: Choose between JKS and PEM TLS certificate formats. Defaults: **JKS**.
 
 In order to authenticate Kafka against a Zookeeper server with `SASL_SSL`, you should provide the environment variables below:
 
@@ -439,8 +441,10 @@ In order to authenticate Kafka against a Zookeeper server with `SASL_SSL`, you s
 * `KAFKA_ZOOKEEPER_TLS_KEYSTORE_PASSWORD`: Kafka Zookeeper keystore file password and key password. No defaults.
 * `KAFKA_ZOOKEEPER_TLS_TRUSTSTORE_PASSWORD`: Kafka Zookeeper truststore file password. No defaults.
 * `KAFKA_ZOOKEEPER_TLS_VERIFY_HOSTNAME`: Verify Zookeeper hostname on TLS certificates. Defaults: **true**.
+* `KAFKA_ZOOKEEPER_TLS_TYPE`: Choose between JKS and PEM TLS certificate formats. Defaults: **JKS**.
 
-> Note: You **must** also use your own certificates for SSL. You can mount your Java Key Stores files (`zookeeper.keystore.jks` and `zookeeper.truststore.jks`) into `/opt/bitnami/kafka/conf/certs`.
+Note: You **must** also use your own certificates for SSL. You can mount your Java Key Stores or PEM files (`zookeeper.keystore.jks|.pem` and `zookeeper.truststore.jks|.pem`) into `/opt/bitnami/kafka/conf/certs`.
+If client authentication is `none` or `want` in Zookeeper, the keystore file is optional.
 
 ### Setting up a Kafka Cluster
 


### PR DESCRIPTION
**Description of the change**

- Adds support for PEM certificate and key files for zookeeper
- Makes the keystore file optional (useful when zookeeper has `ssl.clientAuth` disabled)

`zookeeper.ssl.keystore.type` and `zookeeper.ssl.truststore.type` are not set, as they auto detect the used file extension (unlike `ssl.keystore.type` and `ssl.truststore.type`). To configure which file extension to use `KAFKA_ZOOKEEPER_TLS_TYPE` was added.

The truststore is not optional because, as far as I'm aware, certificate verification can't be disabled (only the hostname verification). 

**Benefits**

PEM files are easier usually easier to generate and manage than JKS files. PEM support was added for Kafka recently. 

**Possible drawbacks**

Not placing a keystore file when the intent is to configure mTLS won't return an error like in the earlier versions (but a warning will be logged).

**Applicable issues**

**Additional information**

[Zookeeper encryption section in the kafka docs](https://kafka.apache.org/documentation/#zk_encryption)
