### PR TITLE
Fix directory for mounted PEM cert lookup

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -282,8 +282,8 @@ kafka_validate() {
             print_validation_error "In order to configure the TLS encryption for Kafka with JKS certs you must mount your kafka.keystore.jks and kafka.truststore.jks certs to the ${KAFKA_MOUNTED_CONF_DIR}/certs directory."
         elif [[ "$KAFKA_CFG_TLS_TYPE" = "PEM" ]] \
             && { [[ ! -f "${KAFKA_CERTS_DIR}/kafka.keystore.pem" ]] || [[ ! -f "${KAFKA_CERTS_DIR}/kafka.keystore.key" ]] || [[ ! -f "${KAFKA_CERTS_DIR}/kafka.truststore.pem" ]]; } \
-            && { [[ ! -f "${KAFKA_MOUNTED_CONF_DIR}/certs/kafka.keystore.pem" ]] || [[ ! -f "${KAFKA_MOUNTED_CONF_DIR}/certs/kafka.keystore.key" ]] || [[ ! -f "${KAFKA_CERTS_DIR}/kafka.truststore.pem" ]]; }; then
-            print_validation_error "In order to configure the TLS encryption for Kafka with PEM certs you must mount your kafka.keystore.pem, kafka.keystore.key and kafka.truststore.jks certs to the ${KAFKA_MOUNTED_CONF_DIR}/certs directory."
+            && { [[ ! -f "${KAFKA_MOUNTED_CONF_DIR}/certs/kafka.keystore.pem" ]] || [[ ! -f "${KAFKA_MOUNTED_CONF_DIR}/certs/kafka.keystore.key" ]] || [[ ! -f "${KAFKA_MOUNTED_CONF_DIR}/certs/kafka.truststore.pem" ]]; }; then
+            print_validation_error "In order to configure the TLS encryption for Kafka with PEM certs you must mount your kafka.keystore.pem, kafka.keystore.key and kafka.truststore.pem certs to the ${KAFKA_MOUNTED_CONF_DIR}/certs directory."
         fi
     elif [[ "${KAFKA_CFG_LISTENERS:-}" =~ SASL ]] || [[ "${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-}" =~ SASL ]]; then
         if [[ -z "$KAFKA_CLIENT_PASSWORD" && -z "$KAFKA_CLIENT_PASSWORDS" ]] && [[ -z "$KAFKA_INTER_BROKER_PASSWORD" ]]; then


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This is a fairly minimal change that fixes an issue I was having with using PEM certificates. The startup script was looking for certificates in the wrong place and reporting a slightly incorrect error. This appears to have been a copy-paste error.

**Benefits**

This makes configuring the container more consistent with the documentation since the pre-run check now looks in the correct location for truststore PEMs when using mounted certificates.

**Possible drawbacks**

Backward compatibility issues, though these shouldn't matter since the fixed behavior is consistent with the pre-run checks.

**Applicable issues**

None that I know of.

**Additional information**

N/A
