### PR TITLE
Kraft-mode

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/kafka/setup.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/kafka/setup.sh
@@ -56,6 +56,7 @@ if [[ ! -z "${KRAFT_ENABLED:-}" ]]; then
     [[ -z "${CLUSTER_ID:-}" ]] && CLUSTER_ID=$($KAFKA_HOME/bin/kafka-storage.sh random-uuid)
     warn "Using KRaft mode (EXPERIMENTAL) as a $role node in cluster: $CLUSTER_ID"
     $KAFKA_HOME/bin/kafka-storage.sh format -t $CLUSTER_ID -c $KAFKA_CONF_FILE
+    kafka_configure_from_environment_variables
 fi
 # Ensure custom initialization scripts are executed
 kafka_custom_init_scripts


### PR DESCRIPTION
This allows the kafka 3.x images to be run in KRaft mode (which is still not recommended for production), as a controller, broker or both. I'm not sure if this is actually worth embedding in the image (you can just as easily put this extra shell logic into a separate script and mount it into the container to be executed as a custom init script). But this KRaft request has come up in #159 and #214 so its at least worth showing a simple way of enabling it.

An example of using this container: `docker run -e ALLOW_PLAINTEXT_LISTENER=yes -e KRAFT_ENABLED=1  -e KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093 bitnami/kafka:kraft`